### PR TITLE
[WIP] handle non-uniqueness in checkpoints

### DIFF
--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -69,7 +69,7 @@ function backsolve_checkpoint_callbacks(sensefun, sol, checkpoints, callback)
   cur_time = Ref(length(checkpoints))
   condition = let checkpoints=checkpoints
     (u,t,integrator) ->
-      checkpoints !== nothing && ((idx = searchsortedfirst(checkpoints, t)) <= length(checkpoints)) && checkpoints[idx] == t
+      checkpoints !== nothing && ((idx = searchsortedlast(checkpoints, t)) <= length(checkpoints)) && checkpoints[idx] == t
   end
   affect! = let sol=sol, cur_time=cur_time, idx=length(prob.u0)
     function (integrator)

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -22,7 +22,8 @@ function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,c
   (checkpointing && checkpoints === nothing) && error("checkpoints must be passed when checkpointing is enabled.")
 
   checkpoint_sol = if checkpointing
-    intervals = map(tuple, @view(checkpoints[1:end-1]), @view(checkpoints[2:end]))
+    _checkpoints = unique(checkpoints)
+    intervals = map(tuple, @view(_checkpoints[1:end-1]), @view(_checkpoints[2:end]))
     interval_end = intervals[end][end]
     tspan[1] > interval_end && push!(intervals, (interval_end, tspan[1]))
     cursor = lastindex(intervals)


### PR DESCRIPTION
@yingboma can you take a good luck and possibly fix up small remaining bugs here? Essentially the idea is that, if the forward pass used callbacks, then you can have non-unique timepoints for the checkpoints. If that's the case, then we want to make sure that we pull one of the values out. The last value? That would be after the callbacks applied. If that makes sense, then we'd want to make sure that the callbacks aren't re-applied in the checkpointing interval calculation. So maybe the first is better? Do you know if unique always gets the first or second? Big questions.