### PR TITLE
[WIP] alternative differentiation choices for noise Jacobian

### DIFF
--- a/src/local_sensitivity/adjoint_common.jl
+++ b/src/local_sensitivity/adjoint_common.jl
@@ -1,4 +1,4 @@
-struct AdjointDiffCache{UF,PF,G,TJ,PJT,uType,JC,GC,PJC,rateType,DG,DI,AI,FM}
+struct AdjointDiffCache{UF,PF,G,TJ,PJT,uType,JC,GC,PJC,PJNC,FCFG,rateType,DG,DI,AI,FM}
   uf::UF
   pf::PF
   g::G
@@ -8,6 +8,8 @@ struct AdjointDiffCache{UF,PF,G,TJ,PJT,uType,JC,GC,PJC,rateType,DG,DI,AI,FM}
   jac_config::JC
   g_grad_config::GC
   paramjac_config::PJC
+  paramjac_noise_tape::PJNC
+  paramjac_noise_config::FCFG
   f_cache::rateType
   dg::DG
   diffvar_idxs::DI
@@ -21,7 +23,7 @@ end
 
 return (AdjointDiffCache, y)
 """
-function adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false)
+function adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false,noiseterm=false)
   prob = sol.prob
   if prob isa DiffEqBase.SteadyStateProblem
     @unpack u0, p = prob
@@ -92,6 +94,7 @@ function adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false)
 
   if sensealg.autojacvec isa ReverseDiffVJP ||
     (sensealg.autojacvec isa Bool && sensealg.autojacvec && DiffEqBase.isinplace(prob))
+
     if prob isa DiffEqBase.SteadyStateProblem
        if DiffEqBase.isinplace(prob)
          tape = ReverseDiff.GradientTape((y, prob.p)) do u,p
@@ -124,7 +127,7 @@ function adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false)
     end
 
     pf = nothing
-  elseif DiffEqBase.has_paramjac(f) || isautojacvec || quad
+  elseif (DiffEqBase.has_paramjac(f) || isautojacvec || quad)
     paramjac_config = nothing
     pf = nothing
   else
@@ -143,8 +146,50 @@ function adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false)
   dg_val .= false
   f_cache = DiffEqBase.isinplace(prob) ? deepcopy(u0) : nothing
 
+  if noiseterm
+    if (sensealg.noise isa ReverseDiffNoise ||
+    (sensealg.noise isa Bool && sensealg.noise && DiffEqBase.isinplace(prob)))
+
+      if DiffEqBase.isinplace(prob)
+        tape = ReverseDiff.JacobianTape((y, prob.p, [tspan[2]])) do u,p,t
+          du1 = similar(p, size(u))
+          f(du1,u,p,first(t))
+          return vec(du1)
+        end
+      else
+        tape = ReverseDiff.JacobianTape((y, prob.p, [tspan[2]])) do u,p,t
+      	   vec(f(u,p,first(t)))
+         end
+       end
+       if compile_tape(sensealg.noise)
+         paramjac_noise_config = ReverseDiff.compile(tape)
+       else
+         paramjac_noise_config = tape
+       end
+       fcfg = ReverseDiff.JacobianConfig((y, prob.p, [tspan[2]]))
+     elseif (sensealg.noise isa Bool && !sensealg.noise)
+       if DiffEqBase.isinplace(prob)
+         pf = DiffEqBase.ParamJacobianWrapper(f,tspan[1],y)
+         paramjac_config = build_param_jac_config(sensealg,pf,y,p)
+       else
+         pf = ParamGradientWrapper(f,tspan[2],y)
+         paramjac_config = nothing
+       end
+       pJ = similar(u0, numindvar, numparams)
+       paramjac_noise_config = nothing
+       fcfg = nothing
+     else
+       paramjac_noise_config = nothing
+       fcfg = nothing
+     end
+   else
+     paramjac_noise_config = nothing
+     fcfg = nothing
+   end
+
+
   adjoint_cache = AdjointDiffCache(uf,pf,pg,J,pJ,dg_val,
-                          jac_config,pg_config,paramjac_config,
+                          jac_config,pg_config,paramjac_config,paramjac_noise_config,fcfg,
                           f_cache,dg,diffvar_idxs,algevar_idxs,
                           factorized_mass_matrix,issemiexplicitdae)
 

--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -11,7 +11,7 @@ end
 
 
 function ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,f,colorvec;noiseterm=false)
-  diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false)
+  diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false,noiseterm=noiseterm)
 
   return ODEBacksolveSensitivityFunction(diffcache,sensealg,discrete,
                                          y,sol.prob,f,colorvec,noiseterm)
@@ -48,13 +48,8 @@ function (S::ODEBacksolveSensitivityFunction)(du,u,p,t)
   if S.noiseterm
     vecjacobian!(dλ, λ, p, t, S, dy=dy)
 
-    for (i, λi) in enumerate(λ)
-      _, back = Zygote.pullback(y, prob.p) do u, p
-        f(u, p, t)[i]
-      end
-      _,tmp2 = back(λi)
-      dgrad[:,i] .= vec(tmp2)
-    end
+    jacNoise!(λ, p, t, S, dgrad=dgrad)
+
   else
     vecjacobian!(dλ, λ, p, t, S, dgrad=dgrad, dy=dy)
   end

--- a/test/local_sensitivity/sde.jl
+++ b/test/local_sensitivity/sde.jl
@@ -179,8 +179,26 @@ sol_oop_sde2 = solve(prob_oop_sde2,EulerHeun(),
 res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_oop_sde2,EulerHeun(),dg!,Array(t)
  	,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
 
+res_sde_u03, res_sde_p3 = adjoint_sensitivities(sol_oop_sde2,EulerHeun(),dg!,Array(t)
+	,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+
+res_sde_u04, res_sde_p4 = adjoint_sensitivities(sol_oop_sde2,EulerHeun(),dg!,Array(t)
+	,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+res_sde_u05, res_sde_p5 = adjoint_sensitivities(sol_oop_sde2,EulerHeun(),dg!,Array(t)
+	,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
+
+
 sol_oop_sde2 = nothing
 GC.gc()
+
+@test isapprox(res_sde_p2, res_sde_p3, rtol = 1e-7)
+@test isapprox(res_sde_p2, res_sde_p4, rtol = 1e-7)
+@test isapprox(res_sde_p2, res_sde_p5, rtol = 1e-7)
+
+@test isapprox(res_sde_u02, res_sde_u03, rtol = 1e-7)
+@test isapprox(res_sde_u02, res_sde_u04, rtol = 1e-7)
+@test isapprox(res_sde_u02, res_sde_u05, rtol = 1e-7)
 
 @info "Diagonal ForwardDiff"
 res_sde_forward2 = ForwardDiff.gradient(GSDE2,p2)

--- a/test/local_sensitivity/sde.jl
+++ b/test/local_sensitivity/sde.jl
@@ -5,6 +5,8 @@ using ForwardDiff, Calculus, ReverseDiff
 using Random
 import Tracker, Zygote
 
+@info "SDE Adjoints"
+
 seed = 100
 Random.seed!(seed)
 abstol = 1e-4


### PR DESCRIPTION
I started to implement more differentiation possibilities for the noise Jacobian. 
https://github.com/SciML/DiffEqSensitivity.jl/issues/259 and https://github.com/SciML/DiffEqSensitivity.jl/issues/249
I am still testing only the oop version and I would add tests for inplace next.

The current solution creates a `tape` using `ReverseDiff` for the full Jacobian (`pJ`). The main problem I faced here was the initialization of the D tapes (one for each column).
I would have preferred something along the lines of 

```
function tape(indx)
	ReverseDiff.JacobianTape((y, p, [tspan[2]])) do u,p,t
		f(u,p,first(t))[indx]
	end
end
paramjac_noise_config = [ReverseDiff.compile(tape(i)) for i in 1:length(D) ]
```
but couldn't make it working yet.. I guess based on this issue https://github.com/JuliaDiff/ReverseDiff.jl/issues/36 that passing `indx` directly in the tape to generalize the version written for the `vecjacobian! `stuff won't work..
Recreating the tape every time in the call to `jacNoise` also seems to be costly.
What is currently missing is a way to pass a paramjac function of the diffusion term to the `SDEAdjointProblem` which could be beneficial, e.g., if `pJ` is constant.