### PR TITLE
SDE Adjoint for scalar noise

### DIFF
--- a/test/local_sensitivity/sde.jl
+++ b/test/local_sensitivity/sde.jl
@@ -30,8 +30,6 @@ end
 
 p2 = [1.01,0.87]
 
-
-
 @testset "SDE oop Tests" begin
   f_oop_linear(u,p,t) = p[1]*u
   σ_oop_linear(u,p,t) = p[2]*u
@@ -298,29 +296,31 @@ end
 
   @info res_sde_p
 
-  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+  ### The following tests are not needed anymore here, as for scalar SDEs it is sufficient to compute the vjps for the dsigma/dp terms
 
-  @info res_sde_p2
-
-  @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
-  @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
-
-  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
-
-  @info res_sde_p2
-
-  @test_broken isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
-  @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-5)
-
-  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
-
-  @info res_sde_p2
-
-  @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-10)
-  @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-10)
+  # res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
+  #     ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+  #
+  # @info res_sde_p2
+  #
+  # @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
+  # @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
+  #
+  # res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
+  #     ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+  #
+  # @info res_sde_p2
+  #
+  # @test_broken isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
+  # @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-5)
+  #
+  # res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
+  #     ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
+  #
+  # @info res_sde_p2
+  #
+  # @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-10)
+  # @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-10)
 
 
   # diagonal noise
@@ -375,3 +375,43 @@ end
 
 
 # scalar noise
+@testset "SDE scalar noise tests" begin
+  using DiffEqNoiseProcess
+
+  f!(du,u,p,t) = (du .= p[1]*u)
+  σ!(du,u,p,t) = (du .= p[2]*u)
+
+  @info "scalar SDE"
+
+  Random.seed!(seed)
+  W = WienerProcess(0.0,0.0,0.0)
+  u0 = rand(2)
+
+  linear_analytic_strat(u0,p,t,W) = @.(u0*exp(p[1]*t+p[2]*W))
+
+  prob = SDEProblem(SDEFunction(f!,σ!,analytic=linear_analytic_strat),σ!,u0,trange,p2,
+    noise=W
+    )
+  sol = solve(prob,EulerHeun(), dt=tend/1e6, save_noise=true)
+
+  @test isapprox(sol.u_analytic,sol.u, atol=2e-5)
+
+  res_sde_u0, res_sde_p = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+    ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
+
+  function compute_grads(sol, scale=1.0)
+    xdis = sol(tarray)
+    helpu1 = [u[1] for u in xdis.u]
+    tmp1 = sum((@. xdis.t*helpu1*helpu1))
+
+    Wtmp = [sol.W(t)[1][1] for t in tarray]
+    tmp2 = sum((@. Wtmp*helpu1*helpu1))
+
+    tmp3 = sum((@. helpu1*helpu1))/helpu1[1]
+
+    return [tmp3, scale*tmp3], [tmp1*(1.0+scale^2), tmp2*(1.0+scale^2)]
+  end
+
+  @test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-6)
+  @test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, atol=1e-6)
+end

--- a/test/local_sensitivity/sde.jl
+++ b/test/local_sensitivity/sde.jl
@@ -296,31 +296,29 @@ end
 
   @info res_sde_p
 
-  ### The following tests are not needed anymore here, as for scalar SDEs it is sufficient to compute the vjps for the dsigma/dp terms
+  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
 
-  # res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
-  #     ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
-  #
-  # @info res_sde_p2
-  #
-  # @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
-  # @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
-  #
-  # res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
-  #     ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
-  #
-  # @info res_sde_p2
-  #
-  # @test_broken isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
-  # @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-5)
-  #
-  # res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
-  #     ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
-  #
-  # @info res_sde_p2
-  #
-  # @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-10)
-  # @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-10)
+  @info res_sde_p2
+
+  @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5)
+  @test isapprox(res_sde_u0, res_sde_u02, rtol = 1e-5)
+
+  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+  @info res_sde_p2
+
+  @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-5) # not broken here because it just uses the vjps
+  @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-5)
+
+  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol_sde,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
+
+  @info res_sde_p2
+
+  @test isapprox(res_sde_p, res_sde_p2, rtol = 1e-10)
+  @test isapprox(res_sde_u0 ,res_sde_u02, rtol = 1e-10)
 
 
   # diagonal noise


### PR DESCRIPTION
This adds a switch for scalar noise (associated issue: https://github.com/SciML/DiffEqSensitivity.jl/issues/254).

For scalar noise, we don't have to consider the full noise Jacobian broadcasted against lambda. Since all dWs are equal for scalar noise, the computation simplifies to another vjp, and can be calculated using `vecjacobian! `with `dgrad=dgrad`. Thus in case of scalar noise, also the choice of the solver is less restrictive. 



