### PR TITLE
change default norm to make ForwardDiffSensitivity test pass

### DIFF
--- a/test/local_sensitivity/branching_derivatives.jl
+++ b/test/local_sensitivity/branching_derivatives.jl
@@ -18,14 +18,14 @@ end
 p = [1., 1., 1., 1.]; u0 = [1.0;1.0]
 prob = ODEProblem(fiip, u0, (0.0, 4.0), p);
 
+internalnorm(u::ForwardDiff.Dual,::Any) = DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(u)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(u)))
+internalnorm(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(x->(DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(x)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(x)))),u) / length(u))
+
 dp1 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardDiffSensitivity(), internalnorm=internalnorm, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
 dp2 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardSensitivity(), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
 dp3 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
 dp4 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP()))), p)
 dp5 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)))), p)
-
-internalnorm(u::ForwardDiff.Dual,::Any) = DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(u)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(u)))
-internalnorm(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(x->(DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(x)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(x)))),u) / length(u))
 
 @test dp1[1] ≈ dp2[1]
 @test dp2[1] ≈ dp3[1]

--- a/test/local_sensitivity/branching_derivatives.jl
+++ b/test/local_sensitivity/branching_derivatives.jl
@@ -6,13 +6,11 @@ function get_param(breakpoints, values, t)
             return values[i]
         end
     end
-
     return values[end]
 end
 
 function fiip(du, u, p, t)
     a = get_param([1., 2., 3.], p[1:4],  t)
-
     du[1] = dx =  a * u[1] - u[1] * u[2]
     du[2] = dy = -a * u[2] + u[1] * u[2]
 end
@@ -20,13 +18,16 @@ end
 p = [1., 1., 1., 1.]; u0 = [1.0;1.0]
 prob = ODEProblem(fiip, u0, (0.0, 4.0), p);
 
-dp1 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardDiffSensitivity(), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
+dp1 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardDiffSensitivity(), internalnorm=internalnorm, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
 dp2 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardSensitivity(), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
 dp3 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
 dp4 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP()))), p)
 dp5 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)))), p)
 
-@test_broken dp1[1] ≈ dp2[1]
+internalnorm(u::ForwardDiff.Dual,::Any) = DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(u)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(u)))
+internalnorm(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(x->(DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(x)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(x)))),u) / length(u))
+
+@test dp1[1] ≈ dp2[1]
 @test dp2[1] ≈ dp3[1]
 @test dp2[1] ≈ dp4[1]
 @test sum(dp4[1]) ≈ sum(dp5[1])

--- a/test/local_sensitivity/branching_derivatives.jl
+++ b/test/local_sensitivity/branching_derivatives.jl
@@ -18,17 +18,16 @@ end
 p = [1., 1., 1., 1.]; u0 = [1.0;1.0]
 prob = ODEProblem(fiip, u0, (0.0, 4.0), p);
 
-internalnorm(u::ForwardDiff.Dual,::Any) = DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(u)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(u)))
-internalnorm(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(x->(DiffEqBase.UNITLESS_ABS2(ForwardDiff.value(x)) + sum(DiffEqBase.UNITLESS_ABS2.(ForwardDiff.partials(x)))),u) / length(u))
-
-dp1 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardDiffSensitivity(), internalnorm=internalnorm, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
-dp2 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardSensitivity(), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
-dp3 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
-dp4 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP()))), p)
-dp5 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)))), p)
+dp1 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardDiffSensitivity(), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
+dp2 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardDiffSensitivity(convert_tspan=true), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
+dp3 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, sensealg = ForwardSensitivity(), saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
+dp4 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12)), p)
+dp5 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP()))), p)
+dp6 = Zygote.gradient(p->sum(solve(prob, Tsit5(), u0=u0, p=p, saveat = 0.1, abstol=1e-12, reltol=1e-12, sensealg = InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true)))), p)
 
 @test dp1[1] ≈ dp2[1]
-@test dp2[1] ≈ dp3[1]
-@test dp2[1] ≈ dp4[1]
-@test sum(dp4[1]) ≈ sum(dp5[1])
-@test all(dp5[1][1:3] .== 0)
+@test dp1[1] ≈ dp3[1]
+@test dp1[1] ≈ dp4[1]
+@test dp1[1] ≈ dp5[1]
+@test sum(dp5[1]) ≈ sum(dp6[1])
+@test all(dp6[1][1:3] .== 0)


### PR DESCRIPTION
@yingboma this is an interesting one, because here the function is constant but the sensitivity portion isn't, so tolerances have no effect on the accuracy of the sensitivity calculation. But it exposes the fact that the norm that we are using on dual numbers might not be the best one, as it doesn't allow for controlling the accuracy of the sensitivities. Should we change the default dual number norm?