### PR TITLE
SDE Adjoint for non-diagonal noise and diagonal noise with mixing terms

### DIFF
--- a/src/local_sensitivity/sensitivity_algorithms.jl
+++ b/src/local_sensitivity/sensitivity_algorithms.jl
@@ -24,12 +24,13 @@ struct BacksolveAdjoint{CS,AD,FDT,VJP,NOISE} <: AbstractAdjointSensitivityAlgori
   autojacvec::VJP
   checkpointing::Bool
   noise::NOISE
+  noisemixing::Bool
 end
 Base.@pure function BacksolveAdjoint(;chunk_size=0,autodiff=true,
                                       diff_type=Val{:central},
                                       autojacvec=autodiff,
-                                      checkpointing=true, noise=true)
-  BacksolveAdjoint{chunk_size,autodiff,diff_type,typeof(autojacvec),typeof(noise)}(autojacvec,checkpointing,noise)
+                                      checkpointing=true, noise=true,noisemixing=false)
+  BacksolveAdjoint{chunk_size,autodiff,diff_type,typeof(autojacvec),typeof(noise)}(autojacvec,checkpointing,noise,noisemixing)
 end
 
 struct InterpolatingAdjoint{CS,AD,FDT,VJP} <: AbstractAdjointSensitivityAlgorithm{CS,AD,FDT}
@@ -91,6 +92,7 @@ end
 @inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :checkpointing) ? alg.checkpointing : false
 @inline ischeckpointing(alg::InterpolatingAdjoint, sol) = alg.checkpointing || !sol.dense
 @inline isnoise(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :noise) ? alg.noise : false
+@inline isnoisemixing(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :noisemixing) ? alg.noisemixing : false
 @inline compile_tape(vjp::ReverseDiffVJP{compile}) where compile = compile
 @inline compile_tape(noise::ReverseDiffNoise{compile}) where compile = compile
 @inline compile_tape(autojacvec::Bool) = false

--- a/test/local_sensitivity/sde.jl
+++ b/test/local_sensitivity/sde.jl
@@ -30,6 +30,7 @@ end
 
 p2 = [1.01,0.87]
 
+
 @testset "SDE oop Tests" begin
   f_oop_linear(u,p,t) = p[1]*u
   σ_oop_linear(u,p,t) = p[2]*u
@@ -371,7 +372,6 @@ end
   @info res_sde_p
 end
 
-
 # scalar noise
 @testset "SDE scalar noise tests" begin
   using DiffEqNoiseProcess
@@ -412,4 +412,254 @@ end
 
   @test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-6)
   @test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, atol=1e-6)
+end
+
+# non-diagonal noise
+@testset "Non-diagonal noise tests" begin
+  Random.seed!(seed)
+
+  u₀ = [0.75,0.5]
+  p = [-1.5,0.05,0.2, 0.01]
+  # Example from Roessler, SIAM J. NUMER. ANAL, 48, 922–952 with d = 2; m = 2
+  function f_nondiag!(du,u,p,t)
+    du[1] = p[1]*u[1] + p[2]*u[2]
+    du[2] = p[2]*u[1] + p[1]*u[2]
+    nothing
+  end
+
+  function g_nondiag!(du,u,p,t)
+    du[1,1] = p[3]*u[1] + p[4]*u[2]
+    du[1,2] = p[3]*u[1] + p[4]*u[2]
+    du[2,1] = p[4]*u[1] + p[3]*u[2]
+    du[2,2] = p[4]*u[1] + p[3]*u[2]
+    nothing
+  end
+
+  function f_nondiag(u,p,t)
+    dx = p[1]*u[1] + p[2]*u[2]
+    dy = p[2]*u[1] + p[1]*u[2]
+    [dx,dy]
+  end
+
+  function g_nondiag(u,p,t)
+    du11 = p[3]*u[1] + p[4]*u[2]
+    du12 = p[3]*u[1] + p[4]*u[2]
+    du21 = p[4]*u[1] + p[3]*u[2]
+    du22 = p[4]*u[1] + p[3]*u[2]
+
+    [du11  du12
+      du21  du22]
+  end
+
+
+  function f_nondiag_analytic(u0,p,t,W)
+    A = [[p[1], p[2]] [p[2], p[1]]]
+    B = [[p[3], p[4]] [p[4], p[3]]]
+    tmp = A*t + B*W[1] + B*W[2]
+    exp(tmp)*u0
+  end
+
+  noise_matrix = similar(p,2,2)
+  noise_matrix .= false
+
+  Random.seed!(seed)
+  prob = SDEProblem(f_nondiag!,g_nondiag!,u₀,trange,p,noise_rate_prototype=noise_matrix)
+  sol = solve(prob, EulerHeun(), dt=tend/1e6, save_noise=true )
+
+  noise_matrix = similar(p,2,2)
+  noise_matrix .= false
+  Random.seed!(seed)
+  proboop = SDEProblem(f_nondiag,g_nondiag,u₀,trange,p,noise_rate_prototype=noise_matrix)
+  soloop = solve(proboop,EulerHeun(), dt=tend/1e6, save_noise=true)
+
+
+
+  res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
+
+  @info res_sde_p
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  function compute_grads_nd(sol)
+    xdis = sol(tarray)
+
+    mat1 = Matrix{Int}(I, 2, 2)
+    mat2 = ones(2,2)-mat1
+
+    tmp1 = similar(p)
+    tmp1 *= false
+
+    tmp2 = similar(xdis.u[1])
+    tmp2 *= false
+
+    for (i, u) in enumerate(xdis)
+      tmp1[1]+=xdis.t[i]*u'*mat1*u
+      tmp1[2]+=xdis.t[i]*u'*mat2*u
+      tmp1[3]+=sum(sol.W(xdis.t[i])[1])*u'*mat1*u
+      tmp1[4]+=sum(sol.W(xdis.t[i])[1])*u'*mat2*u
+
+      tmp2 += u.^2
+    end
+
+    return tmp2 ./ xdis.u[1], tmp1
+  end
+
+  res1, res2 = compute_grads_nd(soloop)
+
+  @test isapprox(res1, res_sde_u0, rtol=1e-4)
+  @test isapprox(res2, res_sde_p', rtol=1e-4)
+
+end
+
+
+
+@testset "diagonal but mixing noise tests" begin
+  Random.seed!(seed)
+  u₀ = [0.75,0.5]
+  p = [-1.5,0.05,0.2, 0.01]
+  # Example from Roessler, SIAM J. NUMER. ANAL, 48, 922–952 with d = 2; m = 2
+  function f_mixing!(du,u,p,t)
+    du[1] = p[1]*u[1] + p[2]*u[2]
+    du[2] = p[2]*u[1] + p[1]*u[2]
+    nothing
+  end
+
+  function g_mixing!(du,u,p,t)
+    du[1] = p[3]*u[1] + p[4]*u[2]
+    du[2] = p[3]*u[1] + p[4]*u[2]
+    nothing
+  end
+
+  function f_mixing(u,p,t)
+    dx = p[1]*u[1] + p[2]*u[2]
+    dy = p[2]*u[1] + p[1]*u[2]
+    [dx,dy]
+  end
+
+  function g_mixing(u,p,t)
+    dx = p[3]*u[1] + p[4]*u[2]
+    dy = p[3]*u[1] + p[4]*u[2]
+    [dx,dy]
+  end
+
+  Random.seed!(seed)
+  prob = SDEProblem(f_mixing!,g_mixing!,u₀,trange,p)
+  sol = solve(prob, EulerHeun(), dt=tend/1e6, save_noise=true )
+
+  Random.seed!(seed)
+  proboop = SDEProblem(f_mixing,g_mixing,u₀,trange,p)
+  soloop = solve(proboop,EulerHeun(), dt=tend/1e6, save_noise=true)
+
+
+  res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noisemixing=true))
+
+  @info res_sde_p
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(),noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false, noisemixing=true))
+
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise(), noisemixing=true))
+
+
+  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false,noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  function GSDE(p)
+    Random.seed!(seed)
+    tmp_prob = remake(prob,u0=eltype(p).(prob.u0),p=p,
+                      tspan=eltype(p).(prob.tspan))
+    sol = solve(tmp_prob,EulerHeun(),dt=tend/1e6,adaptive=false,saveat=Array(t))
+    A = convert(Array,sol)
+    res = g(A,p,nothing)
+  end
+
+  res_sde_forward = ForwardDiff.gradient(GSDE,p)
+
+  @test isapprox(res_sde_p', res_sde_forward, rtol=1e-6)
+
+  function GSDE2(u0)
+    Random.seed!(seed)
+    tmp_prob = remake(prob,u0=u0,p=eltype(p).(prob.p),
+                      tspan=eltype(p).(prob.tspan))
+    sol = solve(tmp_prob,EulerHeun(),dt=tend/1e6,adaptive=false,saveat=Array(t))
+    A = convert(Array,sol)
+    res = g(A,p,nothing)
+  end
+
+  res_sde_forward = ForwardDiff.gradient(GSDE2,u₀)
+
+  @test isapprox(res_sde_forward, res_sde_u0, rtol=1e-6)
 end


### PR DESCRIPTION
I have added one branch for non-diagonal noise processes and one for diagonal noise processes where the noise is more general than du[I] = f(u[I]).

The second one is controlled by 
`isnoisemixing(S.sensealg)`.
By default it currently assumes that the noise is not mixing the terms.

For the ForwardDiff version, I have some problems when using the JacobianConfig option. Therefore, in this part of  `_jacNoise!()` I am currently using directly:
`ForwardDiff.jacobian!(J,uf,dy,y)`
(instead of `jacobian!(J,uf, dy, f_cache, sensealg, jac_config)` )
