### PR TITLE
add tests for adjoints with sparse jacobians

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -47,6 +47,7 @@ ZygoteRules = "0.2"
 julia = "1.2"
 
 [extras]
+AlgebraicMultigrid = "2169fc97-5a83-5252-b627-83903c6c433c"
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
@@ -55,8 +56,9 @@ QuasiMonteCarlo = "8a4e6c94-4038-4cdc-81c3-7e6ffdb2a71b"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "Calculus", "ReverseDiff", "SafeTestsets", "Test", "QuasiMonteCarlo", "Random", "Pkg", "SteadyStateDiffEq", "NLsolve"]
+test = ["AlgebraicMultigrid", "OrdinaryDiffEq", "Calculus", "ReverseDiff", "SafeTestsets", "Test", "QuasiMonteCarlo", "Random", "Pkg", "SteadyStateDiffEq", "NLsolve", "SparseArrays"]

--- a/test/local_sensitivity/sparse_adjoint.jl
+++ b/test/local_sensitivity/sparse_adjoint.jl
@@ -1,0 +1,44 @@
+using DiffEqSensitivity, OrdinaryDiffEq, LinearAlgebra, SparseArrays, Zygote
+import AlgebraicMultigrid
+using Test
+
+foop(u, p, t) = jac(u, p, t) * u
+jac(u, p, t) = spdiagm(0=>p)
+paramjac(u, p, t) = SparseArrays.spdiagm(0=>u)
+@Zygote.adjoint foop(u, p, t) = foop(u, p, t), delta->(jac(u, p, t)' * delta, paramjac(u, p, t)' * delta, zeros(length(u)))
+
+function linsolve_amg!(::Type{Val{:init}}, f, u0, kwargs...)
+    function _linsolve!(x, A, b, update_matrix=false, kwargs...)
+        rs = AlgebraicMultigrid.ruge_stuben(A)
+        copy!(x, solve(rs, b))
+    end
+end
+function linsolve_lu!(::Type{Val{:init}}, f, u0, kwargs...)
+    function _linsolve!(x, A, b, update_matrix=false, kwargs...)
+        _A = lu!(A)
+        ldiv!(x, _A, b)
+    end
+end
+
+n = 2
+p = collect(1.0:n)
+u0 = ones(n)
+tspan = [0.0, 1]
+odef = ODEFunction(foop; jac=jac, jac_prototype=jac(u0, p, 0.0), paramjac=paramjac)
+function g_helper(p; alg=Rosenbrock23(linsolve=linsolve_lu!))
+    prob = ODEProblem(odef, u0, tspan, p)
+    soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-4, reltol=1e-4))[:, end]
+    return soln
+end
+function g(p; kwargs...)
+    soln = g_helper(p; kwargs...)
+    return sum(soln)
+end
+@test isapprox(exp.(p), g_helper(p); atol=1e-3, rtol=1e-3)
+@test isapprox(exp.(p), Zygote.gradient(g, p)[1]; atol=1e-3, rtol=1e-3)#passes but does not use sparse matrices on the backward pass
+@test isapprox(exp.(p), g_helper(p; alg=Rosenbrock23(linsolve=linsolve_amg!)); atol=1e-3, rtol=1e-3)
+@test_broken isapprox(exp.(p), Zygote.gradient(p->g(p; alg=Rosenbrock23(linsolve=linsolve_amg!)), p)[1]; atol=1e-3, rtol=1e-3)
+@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=linsolve_lu!)); atol=1e-1, rtol=1e-1)
+@test_broken isapprox(exp.(p), Zygote.gradient(p->g(p; alg=ImplicitEuler(linsolve=linsolve_lu!)), p)[1]; atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=linsolve_amg!)); atol=1e-1, rtol=1e-1)
+@test_broken isapprox(exp.(p), Zygote.gradient(p->g(p; alg=ImplicitEuler(linsolve=linsolve_amg!)), p)[1]; atol=1e-1, rtol=1e-1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ const is_TRAVIS = haskey(ENV,"TRAVIS")
 if GROUP == "All" || GROUP == "Core1" || GROUP == "Downstream"
     @time @safetestset "Forward Sensitivity" begin include("local_sensitivity/forward.jl") end
     @time @safetestset "Adjoint Sensitivity" begin include("local_sensitivity/adjoint.jl") end
+    @time @safetestset "Sparse Adjoint Sensitivity" begin include("local_sensitivity/sparse_adjoint.jl") end
     @time @safetestset "Second Order Sensitivity" begin include("local_sensitivity/second_order.jl") end
     @time @safetestset "Concrete Solve Derivatives" begin include("local_sensitivity/concrete_solve_derivatives.jl") end
     @time @safetestset "Branching Derivatives" begin include("local_sensitivity/branching_derivatives.jl") end


### PR DESCRIPTION
This is an attempt to create tests for the adjoints on differential equations with sparse Jacobians. Currently, the sparsity is not exploited on the backward pass, making these adjoint calculations not performant.