### PR TITLE
Add jac_prototype for adjoint

### DIFF
--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -1,20 +1,19 @@
-struct ODEBacksolveSensitivityFunction{C<:AdjointDiffCache,Alg<:BacksolveAdjoint,uType,pType,fType<:DiffEqBase.AbstractDiffEqFunction,CV} <: SensitivityFunction
+struct ODEBacksolveSensitivityFunction{C<:AdjointDiffCache,Alg<:BacksolveAdjoint,uType,pType,fType<:DiffEqBase.AbstractDiffEqFunction} <: SensitivityFunction
   diffcache::C
   sensealg::Alg
   discrete::Bool
   y::uType
   prob::pType
   f::fType
-  colorvec::CV
   noiseterm::Bool
 end
 
 
-function ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,f,colorvec;noiseterm=false)
+function ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,f;noiseterm=false)
   diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false,noiseterm=noiseterm)
 
   return ODEBacksolveSensitivityFunction(diffcache,sensealg,discrete,
-                                         y,sol.prob,f,colorvec,noiseterm)
+                                         y,sol.prob,f,noiseterm)
 end
 
 # u = λ'
@@ -94,7 +93,7 @@ end
   len = length(u0)+numparams
   λ = similar(p, len)
   λ .= false
-  sense = ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,f,f.colorvec)
+  sense = ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,f)
 
   init_cb = t !== nothing && tspan[1] == t[end]
   cb = generate_callbacks(sense, g, λ, t, callback, init_cb)
@@ -141,10 +140,10 @@ end
   len = length(u0)+numparams
   λ = similar(p, len)
 
-  sense_drift = ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,sol.prob.f,sol.prob.f.colorvec)
+  sense_drift = ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,sol.prob.f)
 
   diffusion_function = ODEFunction(sol.prob.g, jac=diffusion_jac, paramjac=diffusion_paramjac)
-  sense_diffusion = ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,diffusion_function,diffusion_function.colorvec;noiseterm=true)
+  sense_diffusion = ODEBacksolveSensitivityFunction(g,sensealg,discrete,sol,dg,diffusion_function;noiseterm=true)
 
   init_cb = t !== nothing && tspan[1] == t[end]
   cb = generate_callbacks(sense_drift, g, λ, t, callback, init_cb)

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -1,5 +1,5 @@
 struct ODEInterpolatingAdjointSensitivityFunction{C<:AdjointDiffCache,Alg<:InterpolatingAdjoint,
-                                                  uType,SType,CPS,fType<:DiffEqBase.AbstractDiffEqFunction,CV} <: SensitivityFunction
+                                                  uType,SType,CPS,fType<:DiffEqBase.AbstractDiffEqFunction} <: SensitivityFunction
   diffcache::C
   sensealg::Alg
   discrete::Bool
@@ -7,7 +7,6 @@ struct ODEInterpolatingAdjointSensitivityFunction{C<:AdjointDiffCache,Alg<:Inter
   sol::SType
   checkpoint_sol::CPS
   f::fType
-  colorvec::CV
 end
 
 mutable struct CheckpointSolution{S,I,T}
@@ -17,7 +16,7 @@ mutable struct CheckpointSolution{S,I,T}
   tols::T
 end
 
-function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,checkpoints,colorvec,tols)
+function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,checkpoints,tols)
   tspan = reverse(sol.prob.tspan)
   checkpointing = ischeckpointing(sensealg, sol)
   (checkpointing && checkpoints === nothing) && error("checkpoints must be passed when checkpointing is enabled.")
@@ -38,7 +37,7 @@ function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,c
 
   return ODEInterpolatingAdjointSensitivityFunction(diffcache,sensealg,
                                                     discrete,y,sol,
-                                                    checkpoint_sol,sol.prob.f,colorvec)
+                                                    checkpoint_sol,sol.prob.f,)
 end
 
 function findcursor(intervals, t)
@@ -113,7 +112,7 @@ end
   λ = similar(p, len)
   λ .= false
   sense = ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,
-                                                     checkpoints,f.colorvec,
+                                                     checkpoints,
                                                      (reltol=reltol,abstol=abstol))
 
   init_cb = t !== nothing && tspan[1] == t[end]

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -1,18 +1,17 @@
 struct ODEQuadratureAdjointSensitivityFunction{C<:AdjointDiffCache,Alg<:QuadratureAdjoint,
-                                               uType,SType,fType<:DiffEqBase.AbstractDiffEqFunction,CV} <: SensitivityFunction
+                                               uType,SType,fType<:DiffEqBase.AbstractDiffEqFunction} <: SensitivityFunction
   diffcache::C
   sensealg::Alg
   discrete::Bool
   y::uType
   sol::SType
   f::fType
-  colorvec::CV
 end
 
-function ODEQuadratureAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,colorvec)
+function ODEQuadratureAdjointSensitivityFunction(g,sensealg,discrete,sol,dg)
   diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,sol.prob.f;quad=true)
   return ODEQuadratureAdjointSensitivityFunction(diffcache,sensealg,discrete,
-                                                 y,sol,sol.prob.f,colorvec)
+                                                 y,sol)
 end
 
 # u = λ'
@@ -47,7 +46,7 @@ end
   len = length(u0)
   λ = similar(u0, len)
   λ .= false
-  sense = ODEQuadratureAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,f.colorvec)
+  sense = ODEQuadratureAdjointSensitivityFunction(g,sensealg,discrete,sol,dg)
 
   init_cb = t !== nothing && tspan[1] == t[end]
   z0 = vec(zero(λ))

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -52,10 +52,13 @@ end
   z0 = vec(zero(λ))
   cb = generate_callbacks(sense, g, λ, t, callback, init_cb)
 
+  jac_prototype = sol.prob.f.jac_prototype
+  adjoint_jac_prototype = !sense.discrete || jac_prototype === nothing ? nothing : copy(jac_prototype')
+
   if sol.prob.f.mass_matrix === (I,I)
-    odefun = ODEFunction(sense)
+    odefun = ODEFunction(sense, jac_prototype=adjoint_jac_prototype)
   else
-    odefun = ODEFunction(sense, mass_matrix=sol.prob.f.mass_matrix')
+    odefun = ODEFunction(sense, mass_matrix=sol.prob.f.mass_matrix', jac_prototype=adjoint_jac_prototype)
   end
   return ODEProblem(odefun,z0,tspan,p,callback=cb)
 end

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -55,7 +55,8 @@ end
   jac_prototype = sol.prob.f.jac_prototype
   adjoint_jac_prototype = !sense.discrete || jac_prototype === nothing ? nothing : copy(jac_prototype')
 
-  if sol.prob.f.mass_matrix === (I,I)
+  original_mm = sol.prob.f.mass_matrix
+  if original_mm === I || original_mm === (I,I)
     odefun = ODEFunction(sense, jac_prototype=adjoint_jac_prototype)
   else
     odefun = ODEFunction(sense, mass_matrix=sol.prob.f.mass_matrix', jac_prototype=adjoint_jac_prototype)

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -11,7 +11,7 @@ end
 function ODEQuadratureAdjointSensitivityFunction(g,sensealg,discrete,sol,dg)
   diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,sol.prob.f;quad=true)
   return ODEQuadratureAdjointSensitivityFunction(diffcache,sensealg,discrete,
-                                                 y,sol)
+                                                 y,sol,sol.prob.f)
 end
 
 # u = λ'

--- a/test/local_sensitivity/sparse_adjoint.jl
+++ b/test/local_sensitivity/sparse_adjoint.jl
@@ -1,5 +1,5 @@
 using DiffEqSensitivity, OrdinaryDiffEq, LinearAlgebra, SparseArrays, Zygote
-import AlgebraicMultigrid
+using AlgebraicMultigrid: AlgebraicMultigrid
 using Test
 
 foop(u, p, t) = jac(u, p, t) * u
@@ -8,24 +8,20 @@ paramjac(u, p, t) = SparseArrays.spdiagm(0=>u)
 @Zygote.adjoint foop(u, p, t) = foop(u, p, t), delta->(jac(u, p, t)' * delta, paramjac(u, p, t)' * delta, zeros(length(u)))
 
 function linsolve_amg!(::Type{Val{:init}}, f, u0, kwargs...)
-    function _linsolve!(x, A, b, update_matrix=false, kwargs...)
+    function _linsolve!(x, A, b, update_matrix=false, args...; kwargs...)
         rs = AlgebraicMultigrid.ruge_stuben(A)
-        copy!(x, solve(rs, b))
+        copy!(x, AlgebraicMultigrid.solve(rs, b))
     end
 end
-function linsolve_lu!(::Type{Val{:init}}, f, u0, kwargs...)
-    function _linsolve!(x, A, b, update_matrix=false, kwargs...)
-        _A = lu!(A)
-        ldiv!(x, _A, b)
-    end
-end
+
+linsolve_lu = LinSolveFactorize(lu)
 
 n = 2
 p = collect(1.0:n)
 u0 = ones(n)
 tspan = [0.0, 1]
 odef = ODEFunction(foop; jac=jac, jac_prototype=jac(u0, p, 0.0), paramjac=paramjac)
-function g_helper(p; alg=Rosenbrock23(linsolve=linsolve_lu!))
+function g_helper(p; alg=Rosenbrock23(linsolve=linsolve_lu))
     prob = ODEProblem(odef, u0, tspan, p)
     soln = Array(solve(prob, alg; u0=prob.u0, p=prob.p, abstol=1e-4, reltol=1e-4))[:, end]
     return soln
@@ -37,8 +33,8 @@ end
 @test isapprox(exp.(p), g_helper(p); atol=1e-3, rtol=1e-3)
 @test isapprox(exp.(p), Zygote.gradient(g, p)[1]; atol=1e-3, rtol=1e-3)#passes but does not use sparse matrices on the backward pass
 @test isapprox(exp.(p), g_helper(p; alg=Rosenbrock23(linsolve=linsolve_amg!)); atol=1e-3, rtol=1e-3)
-@test_broken isapprox(exp.(p), Zygote.gradient(p->g(p; alg=Rosenbrock23(linsolve=linsolve_amg!)), p)[1]; atol=1e-3, rtol=1e-3)
-@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=linsolve_lu!)); atol=1e-1, rtol=1e-1)
-@test_broken isapprox(exp.(p), Zygote.gradient(p->g(p; alg=ImplicitEuler(linsolve=linsolve_lu!)), p)[1]; atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), Zygote.gradient(p->g(p; alg=Rosenbrock23(linsolve=linsolve_amg!)), p)[1]; atol=1e-3, rtol=1e-3)
+@test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=linsolve_lu)); atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), Zygote.gradient(p->g(p; alg=ImplicitEuler(linsolve=linsolve_lu)), p)[1]; atol=1e-1, rtol=1e-1)
 @test isapprox(exp.(p), g_helper(p; alg=ImplicitEuler(linsolve=linsolve_amg!)); atol=1e-1, rtol=1e-1)
-@test_broken isapprox(exp.(p), Zygote.gradient(p->g(p; alg=ImplicitEuler(linsolve=linsolve_amg!)), p)[1]; atol=1e-1, rtol=1e-1)
+@test isapprox(exp.(p), Zygote.gradient(p->g(p; alg=ImplicitEuler(linsolve=linsolve_amg!)), p)[1]; atol=1e-1, rtol=1e-1)


### PR DESCRIPTION
Fix #283

`jac_prototype` for quadrature adjoint is straightforward, it's just `jac_prototype'`. `jac_prototype` for interpolating adjoint is
```
[J' 0]
[0  I]
```
since the argument integral is pointwise, the Jacobian is naturally `I`.

Backsolve's `jac_prototype` is
```
[J' 0  0]
[0  I  0]
[0  0  J]
```