### PR TITLE
Add the missing dgdp term in the sensitivity integral

### DIFF
--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -72,7 +72,7 @@ function (S::ODEBacksolveSensitivityFunction)(du,u,p,t)
 
   dλ .*= -one(eltype(λ))
 
-  discrete || accumulate_dgdu!(dλ, y, p, t, S)
+  discrete || accumulate_dgdu!(dλ, y, p, t, S, dgrad)
   return nothing
 end
 

--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -72,7 +72,7 @@ function (S::ODEBacksolveSensitivityFunction)(du,u,p,t)
 
   dλ .*= -one(eltype(λ))
 
-  discrete || accumulate_dgdu!(dλ, y, p, t, S, dgrad)
+  discrete || accumulate_cost!(dλ, y, p, t, S, dgrad)
   return nothing
 end
 

--- a/src/local_sensitivity/derivative_wrappers.jl
+++ b/src/local_sensitivity/derivative_wrappers.jl
@@ -468,7 +468,7 @@ function _jacNoise!(λ, y, p, t, S::SensitivityFunction, isnoise::ZygoteNoise, d
 end
 
 
-function accumulate_dgdu!(dλ, y, p, t, S::SensitivityFunction, dgrad=nothing)
+function accumulate_cost!(dλ, y, p, t, S::SensitivityFunction, dgrad=nothing)
   @unpack dg, dg_val, g, g_grad_config = S.diffcache
   if dg != nothing
     if !(dg isa Tuple)

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -88,7 +88,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
 
   dλ .*= -one(eltype(λ))
 
-  discrete || accumulate_dgdu!(dλ, y, p, t, S)
+  discrete || accumulate_dgdu!(dλ, y, p, t, S, dgrad)
   return nothing
 end
 

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -88,7 +88,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
 
   dλ .*= -one(eltype(λ))
 
-  discrete || accumulate_dgdu!(dλ, y, p, t, S, dgrad)
+  discrete || accumulate_cost!(dλ, y, p, t, S, dgrad)
   return nothing
 end
 

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -29,7 +29,7 @@ function (S::ODEQuadratureAdjointSensitivityFunction)(du,u,p,t)
   vecjacobian!(dλ, y, λ, p, t, S)
   dλ .*= -one(eltype(λ))
 
-  discrete || accumulate_dgdu!(dλ, y, p, t, S)
+  discrete || accumulate_cost!(dλ, y, p, t, S)
   return nothing
 end
 

--- a/src/local_sensitivity/quadrature_adjoint.jl
+++ b/src/local_sensitivity/quadrature_adjoint.jl
@@ -78,7 +78,7 @@ struct AdjointSensitivityIntegrand{pType,uType,rateType,S,AS,PF,PJC,PJT,G}
   dgdp::G
 end
 
-function AdjointSensitivityIntegrand(sol,adj_sol,sensealg,dgdp)
+function AdjointSensitivityIntegrand(sol,adj_sol,sensealg,dgdp=nothing)
   prob = sol.prob
   @unpack f, p, tspan, u0 = prob
   numparams = length(p)

--- a/test/local_sensitivity/adjoint_param.jl
+++ b/test/local_sensitivity/adjoint_param.jl
@@ -1,0 +1,34 @@
+using Test
+using OrdinaryDiffEq
+using DiffEqSensitivity
+using DiffEqBase
+using ForwardDiff
+using QuadGK
+
+function pendulum_eom(dx, x, p, t)
+    dx[1] = x[2]
+    dx[2] = -sin(x[1]) + (-p[1]*sin(x[1]) + p[2]*x[2])  # Second term is a simple controller that stabilizes π
+end
+
+x0 = [0.1, 0.0]
+tspan = (0.0, 10.0)
+p = [-24.05, -19.137]
+prob = ODEProblem(pendulum_eom, x0, tspan, p)
+sol = solve(prob, Vern9(), abstol=1e-8, reltol=1e-8)
+
+g(x, p, t) = 1.0*(x[1] - π)^2 + 1.0*x[2]^2 + 5.0*(-p[1]*sin(x[1]) + p[2]*x[2])^2
+dgdu(out, y, p, t) = ForwardDiff.gradient!(out, y -> g(y, p, t), y)
+dgdp(out, y, p, t) = ForwardDiff.gradient!(out, p -> g(y, p, t), p)
+
+res = adjoint_sensitivities(sol,Vern9(),g,nothing,(dgdu, dgdp),abstol=1e-8,
+                                reltol=1e-8,iabstol=1e-8,ireltol=1e-8)
+
+function G(p)
+    tmp_prob = remake(prob,p=p,u0=convert.(eltype(p), prob.u0))
+    sol = solve(tmp_prob,Vern9(),abstol=1e-8,reltol=1e-8)
+    res,err = quadgk((t)-> g(sol(t), p, t), 0.0,10.0,atol=1e-8,rtol=1e-8)
+    res
+end
+res2 = ForwardDiff.gradient(G,p)
+
+@test res[2]' ≈ res2 atol=1e-5


### PR DESCRIPTION
Fix #92

I did not set up the AD code for computing `dgdp` and the `dgdp` term for the quadrature adjoint. Do you want to do that part? @ChrisRackauckas 