### PR TITLE
Interpolating adjoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ julia:
 env:
   - GROUP=Core1
   - GROUP=Core2
-  - GROUP=Core3
+  - GROUP=SDE1
+  - GROUP=SDE2
   - GROUP=GSA
   - GROUP=DiffEqFlux
 notifications:

--- a/src/local_sensitivity/backsolve_adjoint.jl
+++ b/src/local_sensitivity/backsolve_adjoint.jl
@@ -52,7 +52,7 @@ function (S::ODEBacksolveSensitivityFunction)(du,u,p,t)
     # non-diagonal noise
     dλ    = @view du[1:idx, 1:idx]
     dgrad = @view du[idx+1:end-idx,1:idx]
-    dy    = @view du[end-idx+1:end, end-idx+1:end]
+    dy    = @view du[end-idx+1:end, 1:idx]
   end
 
   copyto!(vec(y), _y)

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -1,12 +1,14 @@
 struct ODEInterpolatingAdjointSensitivityFunction{C<:AdjointDiffCache,Alg<:InterpolatingAdjoint,
-                                                  uType,SType,CPS,fType<:DiffEqBase.AbstractDiffEqFunction} <: SensitivityFunction
+                                                  uType,SType,CPS,pType,fType<:DiffEqBase.AbstractDiffEqFunction} <: SensitivityFunction
   diffcache::C
   sensealg::Alg
   discrete::Bool
   y::uType
   sol::SType
   checkpoint_sol::CPS
+  prob::pType
   f::fType
+  noiseterm::Bool
 end
 
 mutable struct CheckpointSolution{S,I,T}
@@ -16,7 +18,7 @@ mutable struct CheckpointSolution{S,I,T}
   tols::T
 end
 
-function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,checkpoints,tols)
+function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,f,checkpoints,tols;noiseterm=false)
   tspan = reverse(sol.prob.tspan)
   checkpointing = ischeckpointing(sensealg, sol)
   (checkpointing && checkpoints === nothing) && error("checkpoints must be passed when checkpointing is enabled.")
@@ -26,18 +28,31 @@ function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,c
     interval_end = intervals[end][end]
     tspan[1] > interval_end && push!(intervals, (interval_end, tspan[1]))
     cursor = lastindex(intervals)
-    interval = intervals[cursor]
-    cpsol = solve(remake(sol.prob, tspan=interval, u0=sol(interval[1])), sol.alg; tols...)
+    interval = intervals[cursor].-eps(eltype(sol.t))  # floating point end point error with NoiseGrid
+
+    if typeof(sol.prob) <: SDEProblem
+      # replicated noise
+      _sol = deepcopy(sol)
+      @show 36, interval
+      idx1 = searchsortedfirst(_sol.t, interval[1])
+      idx2 = searchsortedfirst(_sol.t, interval[2])
+
+      forwardnoise = DiffEqNoiseProcess.NoiseGrid(_sol.t[idx1:idx2], _sol.W.W[idx1:idx2])
+
+      cpsol = solve(remake(sol.prob, tspan=interval, u0=sol(interval[1]), noise=forwardnoise), sol.alg, save_noise=false; dt=abs(_sol.t[end-1]-_sol.t[end]), tols...)
+    else
+      cpsol = solve(remake(sol.prob, tspan=interval, u0=sol(interval[1])), sol.alg; tols...)
+    end
     CheckpointSolution(cpsol, intervals, cursor, tols)
   else
     nothing
   end
 
-  diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,sol.prob.f)
+  diffcache, y = adjointdiffcache(g,sensealg,discrete,sol,dg,f;quad=false,noiseterm=noiseterm)
 
   return ODEInterpolatingAdjointSensitivityFunction(diffcache,sensealg,
                                                     discrete,y,sol,
-                                                    checkpoint_sol,sol.prob.f,)
+                                                    checkpoint_sol,sol.prob,f,noiseterm)
 end
 
 function findcursor(intervals, t)
@@ -49,9 +64,8 @@ end
 # u = λ'
 # add tstop on all the checkpoints
 function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
-  @unpack sol, y, checkpoint_sol, discrete = S
+  @unpack sol, y, checkpoint_sol, discrete, prob, f = S
   idx = length(y)
-  f = sol.prob.f
 
   if checkpoint_sol === nothing
     if typeof(t) <: ForwardDiff.Dual && eltype(S.y) <: AbstractFloat
@@ -71,8 +85,19 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
       else
         sol(y, interval[1])
       end
-      prob′ = remake(sol.prob, tspan=intervals[cursor′], u0=y)
-      cpsol′ = solve(prob′, sol.alg; dt=abs(cpsol_t[end] - cpsol_t[end-1]), checkpoint_sol.tols...)
+      if typeof(sol.prob) <: SDEProblem
+        _sol = deepcopy(sol)
+        @show 90 interval
+        idx1 = searchsortedfirst(_sol.t, interval[1])
+        idx2 = searchsortedfirst(_sol.t, interval[2])
+
+        forwardnoise = DiffEqNoiseProcess.NoiseGrid(_sol.t[idx1:idx2], _sol.W.W[idx1:idx2])
+        prob′ = remake(prob, tspan=intervals[cursor′], u0=y, noise=forwardnoise)
+        cpsol′ = solve(prob′, sol.alg, noise=forwardnoise, save_noise=false; dt=abs(cpsol_t[end] - cpsol_t[end-1]), checkpoint_sol.tols...)
+      else
+        prob′ = remake(prob, tspan=intervals[cursor′], u0=y)
+        cpsol′ = solve(prob′, sol.alg; dt=abs(cpsol_t[end] - cpsol_t[end-1]), checkpoint_sol.tols...)
+      end
       checkpoint_sol.cpsol = cpsol′
       checkpoint_sol.cursor = cursor′
     end
@@ -81,10 +106,35 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
 
   λ     = @view u[1:idx]
   grad  = @view u[idx+1:end]
-  dλ    = @view du[1:idx]
-  dgrad = @view du[idx+1:end]
 
-  vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad)
+  if length(u) == length(du)
+    dλ    = @view du[1:idx]
+    dgrad = @view du[idx+1:end]
+
+  elseif length(u) != length(du) &&  StochasticDiffEq.is_diagonal_noise(prob) && !isnoisemixing(S.sensealg)
+    idx1 = [length(u)*(i-1)+i for i in 1:idx] # for diagonal indices of [1:idx,1:idx]
+
+    dλ    = @view du[idx1]
+    dgrad = @view du[idx+1:end,1:idx]
+
+  else
+    # non-diagonal noise and noise mixing case
+    dλ    = @view du[1:idx,1:idx]
+    dgrad = @view du[idx+1:end,1:idx]
+  end
+
+  if S.noiseterm
+    if length(u) == length(du)
+      vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad)
+    elseif length(u) != length(du) &&  StochasticDiffEq.is_diagonal_noise(prob) && !isnoisemixing(S.sensealg)
+      vecjacobian!(dλ, y, λ, p, t, S)
+      jacNoise!(λ, y, p, t, S, dgrad=dgrad)
+    else
+      jacNoise!(λ, y, p, t, S, dgrad=dgrad, dλ=dλ)
+    end
+  else
+    vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad)
+  end
 
   dλ .*= -one(eltype(λ))
 
@@ -111,7 +161,7 @@ end
 
   λ = similar(p, len)
   λ .= false
-  sense = ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,
+  sense = ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,f,
                                                      checkpoints,
                                                      (reltol=reltol,abstol=abstol))
 
@@ -145,4 +195,81 @@ end
 
   odefun = ODEFunction(sense, mass_matrix=mm, jac_prototype=adjoint_jac_prototype)
   return ODEProblem(odefun,z0,tspan,p,callback=cb)
+end
+
+
+@noinline function SDEAdjointProblem(sol,sensealg::InterpolatingAdjoint,
+                                     g,t=nothing,dg=nothing;
+                                     checkpoints=sol.t,
+                                     callback=CallbackSet(),
+                                     reltol=nothing, abstol=nothing,
+                                     diffusion_jac=nothing, diffusion_paramjac=nothing,
+                                     kwargs...)
+  @unpack f, p, u0, tspan = sol.prob
+  tspan = reverse(tspan)
+  discrete = t != nothing
+
+  p === DiffEqBase.NullParameters() && error("Your model does not have parameters, and thus it is impossible to calculate the derivative of the solution with respect to the parameters. Your model must have parameters to use parameter sensitivity calculations!")
+  numstates = length(u0)
+  numparams = length(p)
+
+  len = numstates+numparams
+
+  λ = similar(p, len)
+  λ .= false
+
+  sense_drift = ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,sol.prob.f,
+                                                     checkpoints,(reltol=reltol,abstol=abstol))
+
+  diffusion_function = ODEFunction(sol.prob.g, jac=diffusion_jac, paramjac=diffusion_paramjac)
+  sense_diffusion = ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,diffusion_function,
+                                                     checkpoints,(reltol=reltol,abstol=abstol);noiseterm=true)
+
+  init_cb = t !== nothing && tspan[1] == t[end]
+  cb = generate_callbacks(sense_drift, g, λ, t, callback, init_cb)
+  z0 = vec(zero(λ))
+  original_mm = sol.prob.f.mass_matrix
+  if original_mm === I || original_mm === (I,I)
+    mm = I
+  else
+    adjmm = copy(sol.prob.f.mass_matrix')
+    zzz = similar(adjmm, numstates, numparams)
+    fill!(zzz, zero(eltype(zzz)))
+    # using concrate I is slightly more efficient
+    II = Diagonal(I, numparams)
+    mm = [adjmm       zzz
+          copy(zzz')   II]
+  end
+
+  jac_prototype = sol.prob.f.jac_prototype
+  if !sense_drift.discrete || jac_prototype === nothing
+    adjoint_jac_prototype = nothing
+  else
+    _adjoint_jac_prototype = copy(jac_prototype')
+    zzz = similar(_adjoint_jac_prototype, numstates, numparams)
+    fill!(zzz, zero(eltype(zzz)))
+    II = Diagonal(I, numparams)
+    adjoint_jac_prototype = [_adjoint_jac_prototype zzz
+                             copy(zzz')             II]
+  end
+
+  sdefun = SDEFunction(sense_drift,sense_diffusion,mass_matrix=mm,jac_prototype=adjoint_jac_prototype)
+
+  # replicated noise
+  _sol = deepcopy(sol)
+  forwardnoise = DiffEqNoiseProcess.NoiseGrid(_sol.t, _sol.W.W)
+
+  if StochasticDiffEq.is_diagonal_noise(sol.prob) && typeof(sol.W[end])<:Number
+    # scalar noise case
+    noise_matrix = nothing
+  else
+    noise_matrix = similar(z0,length(z0),numstates)
+    noise_matrix .= false
+  end
+
+  return SDEProblem(sdefun,sense_diffusion,z0,tspan,p,
+    callback=cb,
+    noise=forwardnoise,
+    noise_rate_prototype = noise_matrix
+    )
 end

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -92,7 +92,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
         forwardnoise = DiffEqNoiseProcess.NoiseGrid(sol.t[idx1:idx2], sol.W.W[idx1:idx2])
         prob′ = remake(prob, tspan=intervals[cursor′], u0=y, noise=forwardnoise)
         dt = abs(cpsol_t[end]-cpsol_t[end-1])
-        if dt < 1000eps(cpsol_t[end])
+        if dt < 10000eps(cpsol_t[end])
           dt = interval[2] - interval[1]
         end
         cpsol′ = solve(prob′, sol.alg, noise=forwardnoise, save_noise=false; dt=dt, checkpoint_sol.tols...)

--- a/src/local_sensitivity/interpolating_adjoint.jl
+++ b/src/local_sensitivity/interpolating_adjoint.jl
@@ -37,7 +37,7 @@ function ODEInterpolatingAdjointSensitivityFunction(g,sensealg,discrete,sol,dg,f
       idx2 = searchsortedfirst(_sol.t, interval[2])
       forwardnoise = DiffEqNoiseProcess.NoiseGrid(_sol.t[idx1:idx2], _sol.W.W[idx1:idx2])
       dt = abs(_sol.W.dt)
-      if dt < 10000eps(_sol.t[end])
+      if dt < 1000eps(_sol.t[end])
         dt = interval[2] - interval[1]
       end
       cpsol = solve(remake(sol.prob, tspan=interval, u0=sol(interval[1]), noise=forwardnoise), sol.alg, save_noise=false; dt=dt, tols...)
@@ -92,7 +92,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
         forwardnoise = DiffEqNoiseProcess.NoiseGrid(sol.t[idx1:idx2], sol.W.W[idx1:idx2])
         prob′ = remake(prob, tspan=intervals[cursor′], u0=y, noise=forwardnoise)
         dt = abs(cpsol_t[end]-cpsol_t[end-1])
-        if dt < 10000eps(cpsol_t[end])
+        if dt < 1000eps(cpsol_t[end])
           dt = interval[2] - interval[1]
         end
         cpsol′ = solve(prob′, sol.alg, noise=forwardnoise, save_noise=false; dt=dt, checkpoint_sol.tols...)

--- a/src/local_sensitivity/sensitivity_algorithms.jl
+++ b/src/local_sensitivity/sensitivity_algorithms.jl
@@ -33,15 +33,17 @@ Base.@pure function BacksolveAdjoint(;chunk_size=0,autodiff=true,
   BacksolveAdjoint{chunk_size,autodiff,diff_type,typeof(autojacvec),typeof(noise)}(autojacvec,checkpointing,noise,noisemixing)
 end
 
-struct InterpolatingAdjoint{CS,AD,FDT,VJP} <: AbstractAdjointSensitivityAlgorithm{CS,AD,FDT}
+struct InterpolatingAdjoint{CS,AD,FDT,VJP,NOISE} <: AbstractAdjointSensitivityAlgorithm{CS,AD,FDT}
   autojacvec::VJP
   checkpointing::Bool
+  noise::NOISE
+  noisemixing::Bool
 end
 Base.@pure function InterpolatingAdjoint(;chunk_size=0,autodiff=true,
                                          diff_type=Val{:central},
                                          autojacvec=autodiff,
-                                         checkpointing=false)
-  InterpolatingAdjoint{chunk_size,autodiff,diff_type,typeof(autojacvec)}(autojacvec,checkpointing)
+                                         checkpointing=false, noise=true,noisemixing=false)
+  InterpolatingAdjoint{chunk_size,autodiff,diff_type,typeof(autojacvec),typeof(noise)}(autojacvec,checkpointing,noise,noisemixing)
 end
 
 struct QuadratureAdjoint{CS,AD,FDT,VJP} <: AbstractAdjointSensitivityAlgorithm{CS,AD,FDT}

--- a/src/local_sensitivity/sensitivity_interface.jl
+++ b/src/local_sensitivity/sensitivity_interface.jl
@@ -17,6 +17,7 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
     adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
                                abstol=abstol,reltol=reltol)
   end
+
   tstops = ischeckpointing(sensealg, sol) ? checkpoints : similar(sol.t, 0)
   adj_sol = solve(adj_prob,alg;
                   save_everystep=false,save_start=false,saveat=eltype(sol[1])[],

--- a/test/local_sensitivity/sde_checkpointing.jl
+++ b/test/local_sensitivity/sde_checkpointing.jl
@@ -1,0 +1,43 @@
+using Test, LinearAlgebra
+using DiffEqSensitivity, StochasticDiffEq
+using Random
+
+@info "SDE Checkpointing"
+
+seed = 100
+Random.seed!(seed)
+abstol = 1e-4
+reltol = 1e-4
+
+u₀ = [0.5]
+tstart = 0.0
+tend = 0.1
+dt = 0.005
+trange = (tstart, tend)
+t = tstart:dt:tend
+tarray = collect(t)
+
+function g(u,p,t)
+  sum(u.^2.0/2.0)
+end
+
+function dg!(out,u,p,t,i)
+  (out.=-u)
+end
+
+p2 = [1.01,0.87]
+
+
+
+f_oop_linear(u,p,t) = p[1]*u
+σ_oop_linear(u,p,t) = p[2]*u
+
+dt1 = tend/1e3
+
+Random.seed!(seed)
+prob_oop = SDEProblem(f_oop_linear,σ_oop_linear,u₀,trange,p2)
+sol_oop = solve(prob_oop,RKMil(interpretation=:Stratonovich),dt=dt1,adaptive=false,save_noise=true)
+
+
+res_u0, res_p = adjoint_sensitivities(sol_oop,EulerHeun(),dg!,Array(t)
+      ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))

--- a/test/local_sensitivity/sde_checkpointing.jl
+++ b/test/local_sensitivity/sde_checkpointing.jl
@@ -36,8 +36,60 @@ dt1 = tend/1e3
 
 Random.seed!(seed)
 prob_oop = SDEProblem(f_oop_linear,σ_oop_linear,u₀,trange,p2)
-sol_oop = solve(prob_oop,RKMil(interpretation=:Stratonovich),dt=dt1,adaptive=false,save_noise=true)
+sol_oop = solve(prob_oop,EulerHeun(),dt=dt1,adaptive=false,save_noise=true)
 
+@show length(sol_oop)
 
-res_u0, res_p = adjoint_sensitivities(sol_oop,EulerHeun(),dg!,Array(t)
+res_u0, res_p = adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
       ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+
+res_u0a, res_pa = adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
+      ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()),
+      checkpoints=sol_oop.t[1:2:end])
+
+@test isapprox(res_u0, res_u0a, rtol = 1e-5)
+@test isapprox(res_p, res_pa, rtol = 1e-2)
+
+res_u0a, res_pa =  adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
+      ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()),
+      checkpoints=sol_oop.t[1:10:end])
+
+@test isapprox(res_u0, res_u0a, rtol = 1e-5)
+@test isapprox(res_p, res_pa, rtol = 1e-1)
+
+
+
+dt1 = tend/1e4
+
+Random.seed!(seed)
+prob_oop = SDEProblem(f_oop_linear,σ_oop_linear,u₀,trange,p2)
+sol_oop = solve(prob_oop,EulerHeun(),dt=dt1,adaptive=false,save_noise=true)
+
+@show length(sol_oop)
+
+res_u0, res_p = adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
+      ,dt=dt1,adaptive=false,
+      sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+
+res_u0a, res_pa = adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
+      ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()),
+      checkpoints=sol_oop.t[1:2:end])
+
+@test isapprox(res_u0, res_u0a, rtol = 1e-6)
+@test isapprox(res_p, res_pa, rtol = 1e-3)
+
+res_u0a, res_pa =  adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
+      ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()),
+      checkpoints=sol_oop.t[1:10:end])
+
+@test isapprox(res_u0, res_u0a, rtol = 1e-6)
+@test isapprox(res_p, res_pa, rtol = 1e-2)
+
+res_u0a, res_pa =  adjoint_sensitivities(sol_oop,EulerHeun(),dg!,tarray
+      ,dt=dt1,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()),
+      checkpoints=sol_oop.t[1:500:end])
+
+@test isapprox(res_u0, res_u0a, rtol = 1e-3)
+@test isapprox(res_p, res_pa, rtol = 1e-2)

--- a/test/local_sensitivity/sde_nondiag.jl
+++ b/test/local_sensitivity/sde_nondiag.jl
@@ -1,9 +1,8 @@
 using Test, LinearAlgebra
-using OrdinaryDiffEq
-using DiffEqSensitivity, StochasticDiffEq, DiffEqBase
-using ForwardDiff, Calculus, ReverseDiff
+using DiffEqSensitivity, StochasticDiffEq
+using ForwardDiff
 using Random
-import Tracker, Zygote
+
 
 @info "SDE Adjoints"
 
@@ -12,7 +11,6 @@ Random.seed!(seed)
 abstol = 1e-4
 reltol = 1e-4
 
-u₀ = [0.5]
 tstart = 0.0
 tend = 0.1
 dt = 0.005
@@ -28,151 +26,203 @@ function dg!(out,u,p,t,i)
   (out.=-u)
 end
 
-p2 = [1.01,0.87]
-
-
 # non-diagonal noise
 @testset "Non-diagonal noise tests" begin
-  Random.seed!(seed)
+    Random.seed!(seed)
 
-  u₀ = [0.75,0.5]
-  p = [-1.5,0.05,0.2, 0.01]
-  # Example from Roessler, SIAM J. NUMER. ANAL, 48, 922–952 with d = 2; m = 2
-  function f_nondiag!(du,u,p,t)
-    du[1] = p[1]*u[1] + p[2]*u[2]
-    du[2] = p[2]*u[1] + p[1]*u[2]
-    nothing
-  end
+    u₀ = [0.75,0.5]
+    p = [-1.5,0.05,0.2, 0.01]
 
-  function g_nondiag!(du,u,p,t)
-    du[1,1] = p[3]*u[1] + p[4]*u[2]
-    du[1,2] = p[3]*u[1] + p[4]*u[2]
-    du[2,1] = p[4]*u[1] + p[3]*u[2]
-    du[2,2] = p[4]*u[1] + p[3]*u[2]
-    nothing
-  end
+    dtnd = tend/1e6
 
-  function f_nondiag(u,p,t)
-    dx = p[1]*u[1] + p[2]*u[2]
-    dy = p[2]*u[1] + p[1]*u[2]
-    [dx,dy]
-  end
-
-  function g_nondiag(u,p,t)
-    du11 = p[3]*u[1] + p[4]*u[2]
-    du12 = p[3]*u[1] + p[4]*u[2]
-    du21 = p[4]*u[1] + p[3]*u[2]
-    du22 = p[4]*u[1] + p[3]*u[2]
-
-    [du11  du12
-      du21  du22]
-  end
-
-
-  function f_nondiag_analytic(u0,p,t,W)
-    A = [[p[1], p[2]] [p[2], p[1]]]
-    B = [[p[3], p[4]] [p[4], p[3]]]
-    tmp = A*t + B*W[1] + B*W[2]
-    exp(tmp)*u0
-  end
-
-  noise_matrix = similar(p,2,2)
-  noise_matrix .= false
-
-  Random.seed!(seed)
-  prob = SDEProblem(f_nondiag!,g_nondiag!,u₀,trange,p,noise_rate_prototype=noise_matrix)
-  sol = solve(prob, EulerHeun(), dt=tend/1e6, save_noise=true )
-
-  noise_matrix = similar(p,2,2)
-  noise_matrix .= false
-  Random.seed!(seed)
-  proboop = SDEProblem(f_nondiag,g_nondiag,u₀,trange,p,noise_rate_prototype=noise_matrix)
-  soloop = solve(proboop,EulerHeun(), dt=tend/1e6, save_noise=true)
-
-
-
-  res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
-
-  @info res_sde_p
-
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
-
-  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
-
-  @info res_sde_pa
-
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
-
-  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
-
-  @info res_sde_pa
-
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
-
-  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
-
-  @info res_sde_pa
-
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
-
-  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
-
-  @info res_sde_pa
-
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
-
-  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
-
-  @info res_sde_pa
-
-  function compute_grads_nd(sol)
-    xdis = sol(tarray)
-
-    mat1 = Matrix{Int}(I, 2, 2)
-    mat2 = ones(2,2)-mat1
-
-    tmp1 = similar(p)
-    tmp1 *= false
-
-    tmp2 = similar(xdis.u[1])
-    tmp2 *= false
-
-    for (i, u) in enumerate(xdis)
-      tmp1[1]+=xdis.t[i]*u'*mat1*u
-      tmp1[2]+=xdis.t[i]*u'*mat2*u
-      tmp1[3]+=sum(sol.W(xdis.t[i])[1])*u'*mat1*u
-      tmp1[4]+=sum(sol.W(xdis.t[i])[1])*u'*mat2*u
-
-      tmp2 += u.^2
+    # Example from Roessler, SIAM J. NUMER. ANAL, 48, 922–952 with d = 2; m = 2
+    function f_nondiag!(du,u,p,t)
+      du[1] = p[1]*u[1] + p[2]*u[2]
+      du[2] = p[2]*u[1] + p[1]*u[2]
+      nothing
     end
 
-    return tmp2 ./ xdis.u[1], tmp1
-  end
+    function g_nondiag!(du,u,p,t)
+      du[1,1] = p[3]*u[1] + p[4]*u[2]
+      du[1,2] = p[3]*u[1] + p[4]*u[2]
+      du[2,1] = p[4]*u[1] + p[3]*u[2]
+      du[2,2] = p[4]*u[1] + p[3]*u[2]
+      nothing
+    end
 
-  res1, res2 = compute_grads_nd(soloop)
+    function f_nondiag(u,p,t)
+      dx = p[1]*u[1] + p[2]*u[2]
+      dy = p[2]*u[1] + p[1]*u[2]
+      [dx,dy]
+    end
 
-  @test isapprox(res1, res_sde_u0, rtol=1e-4)
-  @test isapprox(res2, res_sde_p', rtol=1e-4)
+    function g_nondiag(u,p,t)
+      du11 = p[3]*u[1] + p[4]*u[2]
+      du12 = p[3]*u[1] + p[4]*u[2]
+      du21 = p[4]*u[1] + p[3]*u[2]
+      du22 = p[4]*u[1] + p[3]*u[2]
+
+      [du11  du12
+        du21  du22]
+    end
+
+
+    function f_nondiag_analytic(u0,p,t,W)
+      A = [[p[1], p[2]] [p[2], p[1]]]
+      B = [[p[3], p[4]] [p[4], p[3]]]
+      tmp = A*t + B*W[1] + B*W[2]
+      exp(tmp)*u0
+    end
+
+    noise_matrix = similar(p,2,2)
+    noise_matrix .= false
+
+    Random.seed!(seed)
+    prob = SDEProblem(f_nondiag!,g_nondiag!,u₀,trange,p,noise_rate_prototype=noise_matrix)
+    sol = solve(prob, EulerHeun(), dt=dtnd, save_noise=true )
+
+    noise_matrix = similar(p,2,2)
+    noise_matrix .= false
+    Random.seed!(seed)
+    proboop = SDEProblem(f_nondiag,g_nondiag,u₀,trange,p,noise_rate_prototype=noise_matrix)
+    soloop = solve(proboop,EulerHeun(), dt=dtnd, save_noise=true)
+
+
+
+    res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=BacksolveAdjoint())
+
+    @info res_sde_p
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise()))
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=InterpolatingAdjoint(noise=false))
+
+    @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=BacksolveAdjoint())
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+    @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=BacksolveAdjoint(noise=false))
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    es_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=InterpolatingAdjoint())
+
+    @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ZygoteNoise()))
+
+    @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+        ,dt=dtnd,adaptive=false,sensealg=InterpolatingAdjoint(noise=false))
+
+    @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+    @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+    @info res_sde_pa
+
+    function compute_grads_nd(sol)
+      xdis = sol(tarray)
+
+      mat1 = Matrix{Int}(I, 2, 2)
+      mat2 = ones(2,2)-mat1
+
+      tmp1 = similar(p)
+      tmp1 *= false
+
+      tmp2 = similar(xdis.u[1])
+      tmp2 *= false
+
+      for (i, u) in enumerate(xdis)
+        tmp1[1]+=xdis.t[i]*u'*mat1*u
+        tmp1[2]+=xdis.t[i]*u'*mat2*u
+        tmp1[3]+=sum(sol.W(xdis.t[i])[1])*u'*mat1*u
+        tmp1[4]+=sum(sol.W(xdis.t[i])[1])*u'*mat2*u
+
+        tmp2 += u.^2
+      end
+
+      return tmp2 ./ xdis.u[1], tmp1
+    end
+
+    res1, res2 = compute_grads_nd(soloop)
+
+    @test isapprox(res1, res_sde_u0, rtol=1e-4)
+    @test isapprox(res2, res_sde_p', rtol=1e-4)
 
 end
 
 
 
 @testset "diagonal but mixing noise tests" begin
+
   Random.seed!(seed)
   u₀ = [0.75,0.5]
   p = [-1.5,0.05,0.2, 0.01]
+
+  dtmix = tend/1e5
+
   # Example from Roessler, SIAM J. NUMER. ANAL, 48, 922–952 with d = 2; m = 2
   function f_mixing!(du,u,p,t)
     du[1] = p[1]*u[1] + p[2]*u[2]
@@ -200,20 +250,23 @@ end
 
   Random.seed!(seed)
   prob = SDEProblem(f_mixing!,g_mixing!,u₀,trange,p)
-  sol = solve(prob, EulerHeun(), dt=tend/1e6, save_noise=true )
+
+  soltsave = collect(trange[1]:dtmix:trange[2])
+  sol = solve(prob, EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave )
 
   Random.seed!(seed)
   proboop = SDEProblem(f_mixing,g_mixing,u₀,trange,p)
-  soloop = solve(proboop,EulerHeun(), dt=tend/1e6, save_noise=true)
+  soloop = solve(proboop,EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave)
 
 
-  res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noisemixing=true))
+  res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noisemixing=true))
 
   @info res_sde_p
 
   res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(),noisemixing=true))
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise(), noisemixing=true))
+
 
   @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
   @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
@@ -221,7 +274,15 @@ end
   @info res_sde_pa
 
   res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false, noisemixing=true))
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noise=false,noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,Array(t)
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(), noisemixing=true))
 
 
   @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
@@ -229,25 +290,27 @@ end
 
   @info res_sde_pa
 
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noisemixing=true))
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
-  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-4)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-4)
 
-  @info res_sde_pa
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true, noise=DiffEqSensitivity.ZygoteNoise()))
 
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise(), noisemixing=true))
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-4)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-4)
 
 
-  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
-  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noise=false, noisemixing=true))
 
-  @info res_sde_pa
+  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-4)
+  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-4)
 
-  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-      ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint(noise=false,noisemixing=true))
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(soloop,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(),noisemixing=true))
 
   @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
   @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
@@ -258,7 +321,7 @@ end
     Random.seed!(seed)
     tmp_prob = remake(prob,u0=eltype(p).(prob.u0),p=p,
                       tspan=eltype(p).(prob.tspan))
-    sol = solve(tmp_prob,EulerHeun(),dt=tend/1e6,adaptive=false,saveat=Array(t))
+    sol = solve(tmp_prob,EulerHeun(),dt=dtmix,adaptive=false,saveat=Array(t))
     A = convert(Array,sol)
     res = g(A,p,nothing)
   end
@@ -271,7 +334,7 @@ end
     Random.seed!(seed)
     tmp_prob = remake(prob,u0=u0,p=eltype(p).(prob.p),
                       tspan=eltype(p).(prob.tspan))
-    sol = solve(tmp_prob,EulerHeun(),dt=tend/1e6,adaptive=false,saveat=Array(t))
+    sol = solve(tmp_prob,EulerHeun(),dt=dtmix,adaptive=false,saveat=Array(t))
     A = convert(Array,sol)
     res = g(A,p,nothing)
   end
@@ -279,4 +342,63 @@ end
   res_sde_forward = ForwardDiff.gradient(GSDE2,u₀)
 
   @test isapprox(res_sde_forward, res_sde_u0, rtol=1e-6)
+
+
+  res_sde_u0, res_sde_p = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noisemixing=true))
+
+  @info res_sde_p
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ZygoteNoise(), noisemixing=true))
+
+
+  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noise=false,noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+      ,dt=dtmix,adaptive=false,sensealg=BacksolveAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(), noisemixing=true))
+
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-4)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-4)
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true, noise=DiffEqSensitivity.ZygoteNoise()))
+
+  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-4)
+  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-4)
+
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noise=false, noisemixing=true))
+
+  @test_broken isapprox(res_sde_u0a, res_sde_u0, rtol=1e-4)
+  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-4)
+
+  res_sde_u0a, res_sde_pa = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
+      ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(),noisemixing=true))
+
+  @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-6)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-6)
+
+  @info res_sde_pa
 end

--- a/test/local_sensitivity/sde_scalar.jl
+++ b/test/local_sensitivity/sde_scalar.jl
@@ -4,7 +4,7 @@ using Random
 
 @info "SDE Adjoints"
 
-seed = 100
+seed = 5
 Random.seed!(seed)
 abstol = 1e-4
 reltol = 1e-4
@@ -46,12 +46,19 @@ p2 = [1.01,0.87]
   prob = SDEProblem(SDEFunction(f!,σ!,analytic=linear_analytic_strat),σ!,u0,trange,p2,
     noise=W
     )
-  sol = solve(prob,EulerHeun(), dt=tend/1e6, save_noise=true)
+  sol = solve(prob,EulerHeun(), dt=tend/1e2, save_noise=true)
 
-  @test isapprox(sol.u_analytic,sol.u, atol=2e-5)
+  @test isapprox(sol.u_analytic,sol.u, atol=1e-4)
 
+  Random.seed!(seed)
   res_sde_u0, res_sde_p = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-    ,dt=tend/1e6,adaptive=false,sensealg=BacksolveAdjoint())
+    ,dt=tend/1e2,adaptive=false,sensealg=BacksolveAdjoint())
+
+  @show res_sde_u0, res_sde_p
+
+  res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+    ,dt=tend/1e2,adaptive=false,sensealg=InterpolatingAdjoint())
+
 
   function compute_grads(sol, scale=1.0)
     xdis = sol(tarray)
@@ -66,53 +73,9 @@ p2 = [1.01,0.87]
     return [tmp3, scale*tmp3], [tmp1*(1.0+scale^2), tmp2*(1.0+scale^2)]
   end
 
-  @test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-6)
-  @test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, atol=1e-6)
+  @test isapprox(res_sde_u0, res_sde_u02,  rtol=1e-4)
+  @test isapprox(res_sde_p, res_sde_p2,  atol=1e-4)
+  @test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-4)
+  @test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, rtol=1e-4)
+
 end
-
-using DiffEqNoiseProcess
-
-f!(du,u,p,t) = (du .= p[1]*u)
-σ!(du,u,p,t) = (du .= p[2]*u)
-
-@info "scalar SDE"
-
-Random.seed!(seed)
-W = WienerProcess(0.0,0.0,0.0)
-u0 = rand(2)
-
-linear_analytic_strat(u0,p,t,W) = @.(u0*exp(p[1]*t+p[2]*W))
-
-prob = SDEProblem(SDEFunction(f!,σ!,analytic=linear_analytic_strat),σ!,u0,trange,p2,
-  noise=W
-  )
-sol = solve(prob,EulerHeun(), dt=tend/1e1, save_noise=true)
-
-@test isapprox(sol.u_analytic,sol.u, atol=1e-4)
-
-Random.seed!(seed)
-res_sde_u0, res_sde_p = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-  ,dt=tend/1e4,adaptive=false,sensealg=BacksolveAdjoint())
-
-@show res_sde_u0, res_sde_p
-
-
-res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
-  ,dt=tend/1e1,adaptive=false,sensealg=InterpolatingAdjoint())
-
-
-function compute_grads(sol, scale=1.0)
-  xdis = sol(tarray)
-  helpu1 = [u[1] for u in xdis.u]
-  tmp1 = sum((@. xdis.t*helpu1*helpu1))
-
-  Wtmp = [sol.W(t)[1][1] for t in tarray]
-  tmp2 = sum((@. Wtmp*helpu1*helpu1))
-
-  tmp3 = sum((@. helpu1*helpu1))/helpu1[1]
-
-  return [tmp3, scale*tmp3], [tmp1*(1.0+scale^2), tmp2*(1.0+scale^2)]
-end
-
-@test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-6)
-@test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, atol=1e-6)

--- a/test/local_sensitivity/sde_scalar.jl
+++ b/test/local_sensitivity/sde_scalar.jl
@@ -1,9 +1,6 @@
 using Test, LinearAlgebra
-using OrdinaryDiffEq
-using DiffEqSensitivity, StochasticDiffEq, DiffEqBase
-using ForwardDiff, Calculus, ReverseDiff
+using DiffEqSensitivity, StochasticDiffEq
 using Random
-import Tracker, Zygote
 
 @info "SDE Adjoints"
 
@@ -72,3 +69,50 @@ p2 = [1.01,0.87]
   @test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-6)
   @test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, atol=1e-6)
 end
+
+using DiffEqNoiseProcess
+
+f!(du,u,p,t) = (du .= p[1]*u)
+σ!(du,u,p,t) = (du .= p[2]*u)
+
+@info "scalar SDE"
+
+Random.seed!(seed)
+W = WienerProcess(0.0,0.0,0.0)
+u0 = rand(2)
+
+linear_analytic_strat(u0,p,t,W) = @.(u0*exp(p[1]*t+p[2]*W))
+
+prob = SDEProblem(SDEFunction(f!,σ!,analytic=linear_analytic_strat),σ!,u0,trange,p2,
+  noise=W
+  )
+sol = solve(prob,EulerHeun(), dt=tend/1e1, save_noise=true)
+
+@test isapprox(sol.u_analytic,sol.u, atol=1e-4)
+
+Random.seed!(seed)
+res_sde_u0, res_sde_p = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+  ,dt=tend/1e4,adaptive=false,sensealg=BacksolveAdjoint())
+
+@show res_sde_u0, res_sde_p
+
+
+res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol,EulerHeun(),dg!,Array(t)
+  ,dt=tend/1e1,adaptive=false,sensealg=InterpolatingAdjoint())
+
+
+function compute_grads(sol, scale=1.0)
+  xdis = sol(tarray)
+  helpu1 = [u[1] for u in xdis.u]
+  tmp1 = sum((@. xdis.t*helpu1*helpu1))
+
+  Wtmp = [sol.W(t)[1][1] for t in tarray]
+  tmp2 = sum((@. Wtmp*helpu1*helpu1))
+
+  tmp3 = sum((@. helpu1*helpu1))/helpu1[1]
+
+  return [tmp3, scale*tmp3], [tmp1*(1.0+scale^2), tmp2*(1.0+scale^2)]
+end
+
+@test isapprox(compute_grads(sol, u0[2]/u0[1])[2], res_sde_p', atol=1e-6)
+@test isapprox(compute_grads(sol, u0[2]/u0[1])[1], res_sde_u0, atol=1e-6)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,16 +18,19 @@ if GROUP == "All" || GROUP == "Core1" || GROUP == "Downstream"
 end
 
 if GROUP == "All" || GROUP == "Core2"
-    @time @safetestset "SDE Adjoint" begin include("local_sensitivity/sde.jl") end
-    @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
-    @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
+    @time @safetestset "Stiff Adjoints" begin include("local_sensitivity/stiff_adjoints.jl") end
     @time @safetestset "Steady State Adjoint" begin include("local_sensitivity/steady_state.jl") end
     @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("local_sensitivity/second_order_odes.jl") end
 end
 
-if GROUP == "All" || GROUP == "Core3"
+if GROUP == "All" || GROUP == "SDE1"
+    @time @safetestset "SDE Adjoint" begin include("local_sensitivity/sde.jl") end
+    @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
+    @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
+end
+
+if GROUP == "All" || GROUP == "SDE2"
     @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end
-    @time @safetestset "Stiff Adjoints" begin include("local_sensitivity/stiff_adjoints.jl") end
 end
 
 if GROUP == "All" || GROUP == "GSA"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,11 +19,11 @@ end
 
 if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "SDE Adjoint" begin include("local_sensitivity/sde.jl") end
-    @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
+    @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end    
 end
 
 if GROUP == "All" || GROUP == "Core3"
-    @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end
+    @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
     @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
     @time @safetestset "Steady State Adjoint" begin include("local_sensitivity/steady_state.jl") end
     @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("local_sensitivity/second_order_odes.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,11 +22,11 @@ if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
     @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
     @time @safetestset "Steady State Adjoint" begin include("local_sensitivity/steady_state.jl") end
+    @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("local_sensitivity/second_order_odes.jl") end
 end
 
 if GROUP == "All" || GROUP == "Core3"
     @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end
-    @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("local_sensitivity/second_order_odes.jl") end
     @time @safetestset "Stiff Adjoints" begin include("local_sensitivity/stiff_adjoints.jl") end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,7 @@ end
 if GROUP == "All" || GROUP == "Core3"
     @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
     @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end
+    @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
     @time @safetestset "Steady State Adjoint" begin include("local_sensitivity/steady_state.jl") end
     @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("local_sensitivity/second_order_odes.jl") end
     @time @safetestset "Stiff Adjoints" begin include("local_sensitivity/stiff_adjoints.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,13 +19,13 @@ end
 
 if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "SDE Adjoint" begin include("local_sensitivity/sde.jl") end
-    @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end    
-end
-
-if GROUP == "All" || GROUP == "Core3"
     @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
     @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
     @time @safetestset "Steady State Adjoint" begin include("local_sensitivity/steady_state.jl") end
+end
+
+if GROUP == "All" || GROUP == "Core3"
+    @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end
     @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("local_sensitivity/second_order_odes.jl") end
     @time @safetestset "Stiff Adjoints" begin include("local_sensitivity/stiff_adjoints.jl") end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,10 +19,10 @@ end
 
 if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "SDE Adjoint" begin include("local_sensitivity/sde.jl") end
+    @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
 end
 
 if GROUP == "All" || GROUP == "Core3"
-    @time @safetestset "SDE Scalar Noise" begin include("local_sensitivity/sde_scalar.jl") end
     @time @safetestset "SDE Non-Diagonal Noise" begin include("local_sensitivity/sde_nondiag.jl") end
     @time @safetestset "SDE Checkpointing" begin include("local_sensitivity/sde_checkpointing.jl") end
     @time @safetestset "Steady State Adjoint" begin include("local_sensitivity/steady_state.jl") end


### PR DESCRIPTION
This PR adds the `InterpolatingAdjoint` method for SDEs from issue #251. It is (like BacksolveAdjoint) based on  `NoiseGrid` at the moment. 

The tests cover scalar, diagonal, diagonal mixing, and non-diagonal noise processes for all possible options of the noise process. I didn't include all possibilities for the vjps so far . For `noise=false ` I had to put some tests_broken/ relax the testing case quite a bit in a few cases.  

It currently handles floating point issues by checking if the checkpoints are unique:
```Julia
if length(unique(round.(checkpoints, digits=13))) != length(checkpoints)
    @warn "The given checkpoints are not unique. To avoid issues in the interpolation the checkpoints were redefined. You may want to check sol.t if default checkpoints were used."
    checkpoints = unique(round.(checkpoints, digits=13))
  end
```