### PR TITLE
Add ContinuousCallback tests 

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -362,7 +362,7 @@ function separate_nonunique(t)
     itrs = nothing
   else
     maxoc = maximum(occurances)
-    maxoc > 2 && warning("More than two occurances of the same time point. Please report this.")
+    maxoc > 2 && error("More than two occurances of the same time point. Please report this.")
     # handle also more than two occurances
     itrs = [ts[occurances .>= i] for i=2:maxoc]
   end

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -87,10 +87,6 @@ end
 
 function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,VectorContinuousCallback},sensealg)
 
-    if typeof(cb) <: Union{ContinuousCallback,VectorContinuousCallback}
-        error("Continuous callbacks are currently not supported with continuous adjoint methods. Please use a discrete adjoint method like ReverseDiffAdjoint.")
-    end
-
     function affect!(integrator)
 
         local _p

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -18,6 +18,7 @@ p = [1.5,1.0,3.0,1.0]; u0 = [1.0;1.0]
 prob = ODEProblem(fiip,u0,(0.0,10.0),p)
 proboop = ODEProblem(foop,u0,(0.0,10.0),p)
 
+println("Discrete Callbacks")
 ### callback with no effect
 
 condition(u,t,integrator) = t == 5
@@ -336,8 +337,185 @@ dstuff = ForwardDiff.gradient(
 @test du02 ≈ dstuff[1:2]
 @test dp2 ≈ dstuff[3:6]
 
-### SDEs
+#### ContinuousCallback
+println("Continuous Callbacks")
+function f(du,u,p,t)
+  #Bouncing Ball
+  du[1] = u[2]
+  du[2] = -p[1]
+end
 
+# no saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint
+
+tstop = 3.1943828249997
+vbefore = -31.30495168499705
+vafter = 25.04396134799764
+
+u0 = [50.0,0.0]
+tspan = (0.0,5.0)
+p = [9.8, 0.8]
+
+prob = ODEProblem(f,u0,tspan,p)
+
+function condition(u,t,integrator) # Event when event_f(u,t) == 0
+   t - tstop
+end
+function affect!(integrator)
+  integrator.u[2] += vafter-vbefore
+end
+cb = ContinuousCallback(condition,affect!,save_positions=(false,false))
+
+
+condition2(u,t,integrator) = t == tstop
+affect2!(integrator) = (integrator.u[2] += vafter-vbefore)
+cb2 = DiscreteCallback(condition2,affect2!,save_positions=(false,false))
+
+du01,dp1 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb2,tstops=[tstop],
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+du02,dp2 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb,
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+dstuff = ForwardDiff.gradient((θ)-> sum(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],
+   	callback=cb,saveat=tspan[2], save_start=false)),[u0;p])
+
+@info dstuff
+@test du01 ≈ dstuff[1:2]
+@test dp1 ≈ dstuff[3:4]
+@test du02 ≈ dstuff[1:2]
+@test dp2 ≈ dstuff[3:4]
+
+# no saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint by slicing
+du01,dp1 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb2,tstops=[tstop],
+   sensealg=BacksolveAdjoint())[end]),u0,p)
+
+du02,dp2 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb,
+   sensealg=BacksolveAdjoint())[end]),u0,p)
+
+dstuff = ForwardDiff.gradient((θ)-> sum(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],
+   	callback=cb)[end]),[u0;p])
+
+@info dstuff
+@test du01 ≈ dstuff[1:2]
+@test dp1 ≈ dstuff[3:4]
+@test du02 ≈ dstuff[1:2]
+@test dp2 ≈ dstuff[3:4]
+
+# with saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint
+cb = ContinuousCallback(condition,affect!,save_positions=(true,true))
+cb2 = DiscreteCallback(condition2,affect2!,save_positions=(true,true))
+
+du01,dp1 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb2,tstops=[tstop],
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+du02,dp2 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb,
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+dstuff = ForwardDiff.gradient((θ)-> sum(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],
+   	callback=cb,saveat=tspan[2], save_start=false)),[u0;p])
+
+@info dstuff
+@test du01 ≈ dstuff[1:2]
+@test dp1 ≈ dstuff[3:4]
+@test du02 ≈ dstuff[1:2]
+@test dp2 ≈ dstuff[3:4]
+
+# with saving in Callbacks; prescribed vafter and vbefore; loss on the endpoint by slicing
+du01,dp1 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb2,tstops=[tstop],
+   sensealg=BacksolveAdjoint())[end]),u0,p)
+
+du02,dp2 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb,
+   sensealg=BacksolveAdjoint())[end]),u0,p)
+
+dstuff = ForwardDiff.gradient((θ)-> sum(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],
+   	callback=cb)[end]),[u0;p])
+
+@info dstuff
+@test_broken du01 ≈ dstuff[1:2] # zero gradients?
+@test_broken dp1 ≈ dstuff[3:4] # zero gradients?
+@test_broken du02 ≈ dstuff[1:2]  # zero gradients?
+@test_broken dp2 ≈ dstuff[3:4] # zero gradients?
+
+# with saving in Callbacks;  different affect function
+function condition(u,t,integrator) # Event when event_f(u,t) == 0
+   t - tstop
+end
+function affect!(integrator)
+  integrator.u[2] = -integrator.p[2]*integrator.u[2]
+end
+cb = ContinuousCallback(condition,affect!,save_positions=(true,true))
+
+condition2(u,t,integrator) = t == tstop
+affect2!(integrator) = (integrator.u[2] = -integrator.p[2]*integrator.u[2])
+cb2 = DiscreteCallback(condition2,affect2!,save_positions=(true,true))
+
+du01,dp1 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb2,tstops=[tstop],
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+du02,dp2 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb,
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+dstuff = ForwardDiff.gradient((θ)-> sum(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],
+   	callback=cb,saveat=tspan[2], save_start=false)),[u0;p])
+
+@info dstuff
+@test_broken du01 ≈ dstuff[1:2]
+@test_broken dp1 ≈ dstuff[3:4]
+@test_broken du02 ≈ dstuff[1:2]
+@test_broken dp2 ≈ dstuff[3:4]
+
+# with saving in Callbacks; state-dependent condition function
+
+function condition(u,t,integrator) # Event when event_f(u,t) == 0
+   u[1]
+end
+
+function affect!(integrator)
+  integrator.u[2] += vafter-vbefore
+end
+cb = ContinuousCallback(condition,affect!,save_positions=(true,true))
+
+du02,dp2 = Zygote.gradient(
+  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
+   callback=cb,
+   sensealg=BacksolveAdjoint(),
+   saveat=tspan[2], save_start=false)),u0,p)
+
+dstuff = ForwardDiff.gradient((θ)-> sum(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],
+   	callback=cb,saveat=tspan[2], save_start=false)),[u0;p])
+
+@info dstuff, [du02;dp2]
+@test_broken du02 ≈ dstuff[1:2]
+@test_broken dp2 ≈ dstuff[3:4]
+
+### SDEs
+println("SDE+Callbacks")
 function dt!(du, u, p, t)
   x, y = u
   α, β, δ, γ = p


### PR DESCRIPTION
Handling a `ContinuousCallback`  in the adjoints (#374) seems to work already equally well as in case of `DiscreteCallback`s.

For example, defining a `ContinuousCallback` with stopping time `tstop`:
```julia
function condition(u,t,integrator) 
   t - tstop
end
function affect!(integrator)
  integrator.u[2] += vafter-vbefore
end
cb = ContinuousCallback(condition,affect!
```
works properly.

Based on the test set, there are however also a few things which don't work yet.
1. When the condition is state dependent, the `ContinuousCallbacks` are not yet working
```julia
function condition(u,t,integrator) # Event when event_f(u,t) == 0
   u[1]
end
```
2.  The affect function must currently be written with a `+=`. This also holds for `DiscreteCallback`s. So, so tests with, e.g.,
```julia
function affect!(integrator)
  integrator.u[2] = -integrator.p[2]*integrator.u[2]
end
```
or
```julia
function affect!(integrator)
  integrator.u[2] = 2.0
end
```
are broken.
3. If the position is saved, i.e., `save_positions=(true,true)`. Then, gradients are dropped when slices on the solution are used
```julia
du01,dp1 = Zygote.gradient(
  (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,
   callback=cb,
   sensealg=BacksolveAdjoint())[end]),u0,p)
```
This also holds for both types of callbacks.