### PR TITLE
Fix ReverseDiffAdjoint

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -391,7 +391,6 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ReverseDiffAdjoin
     else
       u = map(ReverseDiff.value,sol.u)
     end
-
     Array(sol)
   end
 
@@ -402,7 +401,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ReverseDiffAdjoin
   typeof(p) <: DiffEqBase.NullParameters || ReverseDiff.value!(tp, p)
   ReverseDiff.forward_pass!(tape)
   function reversediff_adjoint_backpass(ybar)
-    ReverseDiff.increment_deriv!(output, ybar)
+    ReverseDiff.increment_deriv!(output, Array(VectorOfArray(ybar)))
     ReverseDiff.reverse_pass!(tape)
     (nothing,nothing,ReverseDiff.deriv(tu),ReverseDiff.deriv(tp),nothing,ntuple(_->nothing, length(args))...)
   end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -401,7 +401,8 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ReverseDiffAdjoin
   typeof(p) <: DiffEqBase.NullParameters || ReverseDiff.value!(tp, p)
   ReverseDiff.forward_pass!(tape)
   function reversediff_adjoint_backpass(ybar)
-    ReverseDiff.increment_deriv!(output, Array(VectorOfArray(ybar)))
+    _ybar = eltype(ybar) <: AbstractArray ? Array(VectorOfArray(ybar)) : ybar
+    ReverseDiff.increment_deriv!(output, _ybar)
     ReverseDiff.reverse_pass!(tape)
     (nothing,nothing,ReverseDiff.deriv(tu),ReverseDiff.deriv(tp),nothing,ntuple(_->nothing, length(args))...)
   end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -392,7 +392,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ReverseDiffAdjoin
       u = map(ReverseDiff.value,sol.u)
     end
 
-    sol
+    Array(sol)
   end
 
   tape = ReverseDiff.GradientTape(reversediff_adjoint_forwardpass,(u0, p))
@@ -406,7 +406,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ReverseDiffAdjoin
     ReverseDiff.reverse_pass!(tape)
     (nothing,nothing,ReverseDiff.deriv(tu),ReverseDiff.deriv(tp),nothing,ntuple(_->nothing, length(args))...)
   end
-  DiffEqBase.sensitivity_solution(sol,u,t),reversediff_adjoint_backpass
+  Array(VectorOfArray(u)),reversediff_adjoint_backpass
 end
 
 

--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"
 DiffEqFlux = "aae7a2af-3d4f-5e19-a356-7da93b79d9d0"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"

--- a/test/downstream/callback_reversediff.jl
+++ b/test/downstream/callback_reversediff.jl
@@ -1,4 +1,4 @@
-using DiffEqFlux, OrdinaryDiffEq, Flux, DiffEqSensitivity, Test
+using DiffEqFlux, OrdinaryDiffEq, Flux, DiffEqSensitivity, DiffEqCallbacks, Test
 u0 = Float32[2.; 0.]
 datasize = 100
 tspan = (0.0f0,10.5f0)

--- a/test/downstream/callback_reversediff.jl
+++ b/test/downstream/callback_reversediff.jl
@@ -56,4 +56,4 @@ cba()
 ps = Flux.params(p)
 data = Iterators.repeated((), 200)
 Flux.train!(loss_n_ode, ps, data, ADAM(0.05), cb = cba)
-@test loss_n_ode() < 0.1
+@test loss_n_ode() < 0.4

--- a/test/downstream/callback_reversediff.jl
+++ b/test/downstream/callback_reversediff.jl
@@ -1,0 +1,59 @@
+using DiffEqFlux, OrdinaryDiffEq, Flux, DiffEqSensitivity, Test
+u0 = Float32[2.; 0.]
+datasize = 100
+tspan = (0.0f0,10.5f0)
+dosetimes = [1.0,2.0,4.0,8.0]
+
+function affect!(integrator)
+    integrator.u = integrator.u.+1
+end
+cb_ = PresetTimeCallback(dosetimes,affect!,save_positions=(false,false))
+function trueODEfunc(du,u,p,t)
+    du .= -u
+end
+t = range(tspan[1],tspan[2],length=datasize)
+
+prob = ODEProblem(trueODEfunc,u0,tspan)
+ode_data = Array(solve(prob,Tsit5(),callback=cb_,saveat=t))
+dudt2 = Chain(Dense(2,50,tanh),
+             Dense(50,2))
+p,re = Flux.destructure(dudt2) # use this p as the initial condition!
+
+function dudt(du,u,p,t)
+    du[1:2] .= -u[1:2]
+    du[3:end] .= re(p)(u[1:2]) #re(p)(u[3:end])
+end
+z0 = Float32[u0;u0]
+prob = ODEProblem(dudt,z0,tspan)
+
+affect!(integrator) = integrator.u[1:2] .= integrator.u[3:end]
+cb = PresetTimeCallback(dosetimes,affect!,save_positions=(false,false))
+
+function predict_n_ode()
+    _prob = remake(prob,p=p)
+    Array(solve(_prob,Tsit5(),u0=z0,p=p,callback=cb,saveat=t,sensealg=ReverseDiffAdjoint()))[1:2,:]
+    #Array(solve(prob,Tsit5(),u0=z0,p=p,saveat=t))[1:2,:]
+end
+
+function loss_n_ode()
+    pred = predict_n_ode()
+    loss = sum(abs2,ode_data .- pred)
+    loss
+end
+loss_n_ode() # n_ode.p stores the initial parameters of the neural ODE
+
+cba = function (;doplot=false) #callback function to observe training
+  pred = predict_n_ode()
+  display(sum(abs2,ode_data .- pred))
+  # plot current prediction against data
+  #pl = scatter(t,ode_data[1,:],label="data")
+  #scatter!(pl,t,pred[1,:],label="prediction")
+  #display(plot(pl))
+  return false
+end
+cba()
+
+ps = Flux.params(p)
+data = Iterators.repeated((), 200)
+Flux.train!(loss_n_ode, ps, data, ADAM(0.05), cb = cba)
+@test loss_n_ode() < 0.1

--- a/test/downstream/sde_neural.jl
+++ b/test/downstream/sde_neural.jl
@@ -25,9 +25,8 @@ end
 datasize = 10
 tspan = (0.0f0, 3.0f0)
 tsteps = range(tspan[1], tspan[2], length = datasize)
-u0 = Float32[1.0, 1.0, 1.0, 1.0]
-
-p_ = Float32[1.1, 1.0, 0.0, 2.0, 1.0, 1.0, 1e-6, 1.0]
+u0 = [1.0, 1.0, 1.0, 1.0]
+p_ = [1.1, 1.0, 0.0, 2.0, 1.0, 1.0, 1e-6, 1.0]
 
 prob = SDEProblem(sys!, noise!, u0, tspan, p_)
 ensembleprob = EnsembleProblem(prob)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,6 +54,8 @@ end
 
 if GROUP == "DiffEqFlux"
     activate_downstream_env()
+    @time @safetestset "Callback - ReverseDiff" begin include("downstream/callback_reversediff.jl") end
     @time @safetestset "SDE - Neural" begin include("downstream/sde_neural.jl") end
+
 end
 end


### PR DESCRIPTION
https://www.reddit.com/r/Julia/comments/l3243t/odd_behavior_neural_network_hybrid_differential/ found that this change needed to be rolled back. While it doesn't exactly conform to the interface, it seems ReverseDiff just cannot support the sol object directly, so this needs to be done for correctness. Because our other callback adjoint tests didn't seem to catch this, I added a downstream test on that case specifically to catch gradient issues here.