### PR TITLE
RODE Backsolve and InterpolatingAdjoint

### DIFF
--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -33,8 +33,8 @@ export extract_local_sensitivities
 
 export ODEForwardSensitivityFunction, ODEForwardSensitivityProblem, SensitivityFunction,
        ODEAdjointSensitivityProblem, ODEAdjointProblem, AdjointSensitivityIntegrand,
-       SDEAdjointProblem, SensitivityAlg,
-       adjoint_sensitivities, adjoint_sensitivities_u0 
+       SDEAdjointProblem, RODEAdjointProblem, SensitivityAlg,
+       adjoint_sensitivities, adjoint_sensitivities_u0
 
 export BacksolveAdjoint, QuadratureAdjoint, InterpolatingAdjoint,
        TrackerAdjoint, ZygoteAdjoint, ReverseDiffAdjoint,

--- a/src/backsolve_adjoint.jl
+++ b/src/backsolve_adjoint.jl
@@ -207,9 +207,7 @@ end
 
   # replicated noise
   _sol = deepcopy(sol)
-
   backwardnoise = reverse(_sol.W)
-  #backwardnoise = DiffEqNoiseProcess.NoiseGrid(reverse!(_sol.t),reverse!( _sol.W.W))
 
   if StochasticDiffEq.is_diagonal_noise(sol.prob) && typeof(sol.W[end])<:Number
     # scalar noise case
@@ -274,9 +272,7 @@ end
 
   # replicated noise
   _sol = deepcopy(sol)
-
   backwardnoise = reverse(_sol.W)
-  #backwardnoise = DiffEqNoiseProcess.NoiseGrid(reverse!(_sol.t),reverse!( _sol.W.W))
 
   if StochasticDiffEq.is_diagonal_noise(sol.prob) && typeof(sol.W[end])<:Number
     # scalar noise case

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -77,8 +77,12 @@ end
 
 function choose_dt(dt, ts, interval)
   if dt < 1000eps(interval[2])
-    dt = ts[end-1]-ts[end-2]
-    if dt < 1000eps(interval[2])
+    if length(ts) > 2
+      dt = ts[end-1]-ts[end-2]
+      if dt < 1000eps(interval[2])
+        dt = interval[2] - interval[1]
+      end
+    else
       dt = interval[2] - interval[1]
     end
   end

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -101,8 +101,6 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t,W)
 
   λ,grad,y,dλ,dgrad,dy = split_states(du,u,t,S)
 
-
-
   vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad, W=W)
 
   dλ .*= -one(eltype(λ))

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -13,15 +13,23 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
                                    callback = nothing,
                                    kwargs...)
 
-  if sol.prob isa SDEProblem
-    adj_prob = SDEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
-                               callback = callback,
-                               abstol=abstol,reltol=reltol,
-                               corfunc_analytical=corfunc_analytical)
-  else
+  if sol.prob isa ODEProblem
     adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
                                  callback = callback,
                                  abstol=abstol,reltol=reltol)
+
+  elseif sol.prob isa SDEProblem
+    adj_prob = SDEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
+                                 callback = callback,
+                                 abstol=abstol,reltol=reltol,
+                                 corfunc_analytical=corfunc_analytical)
+  elseif sol.prob isa RODEProblem
+    adj_prob = RODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
+                                callback = callback,
+                                abstol=abstol,reltol=reltol,
+                                corfunc_analytical=corfunc_analytical)
+  else
+    error("Continuous adjoint sensitivities are only supported for ODE/SDE/RODE problems.")
   end
 
   tstops = ischeckpointing(sensealg, sol) ? checkpoints : similar(sol.t, 0)

--- a/test/downstream/callback_reversediff.jl
+++ b/test/downstream/callback_reversediff.jl
@@ -1,4 +1,8 @@
 using DiffEqFlux, OrdinaryDiffEq, Flux, DiffEqSensitivity, DiffEqCallbacks, Test
+using Random
+
+Random.seed!(1234)
+
 u0 = Float32[2.; 0.]
 datasize = 100
 tspan = (0.0f0,10.5f0)

--- a/test/rode.jl
+++ b/test/rode.jl
@@ -181,19 +181,6 @@ end
   @test dpReverseDiff ≈ dp' rtol=1e-2
 
   # isautojacvec = false and with jac and paramjac
-  function jac(J,u,p,t,W)
-    J[1,1] = p[1]*sin(W[1] - W[2])
-    J[2,1] = zero(u[1])
-    J[1,2] = zero(u[1])
-    J[2,2] = p[2]*cos(W[1] + W[2])
-  end
-
-  function paramjac(J,u,p,t,W)
-    J[1,1] = u[1]*sin(W[1] - W[2])
-    J[2,1] = zero(u[1])
-    J[1,2] = zero(u[1])
-    J[2,2] = u[2]*cos(W[1] + W[2])
-  end
   Random.seed!(seed)
   faug = RODEFunction(f,jac=jac,paramjac=paramjac)
   prob_aug = RODEProblem{true}(faug,u0,tspan,p)
@@ -371,19 +358,6 @@ end
   @test dpReverseDiff ≈ dp' rtol=1e-2
 
   # isautojacvec = false and with jac and paramjac
-  function jac(J,u,p,t,W)
-    J[1,1] = p[1]*sin(W[1] - W[2])
-    J[2,1] = zero(u[1])
-    J[1,2] = zero(u[1])
-    J[2,2] = p[2]*cos(W[1] + W[2])
-  end
-
-  function paramjac(J,u,p,t,W)
-    J[1,1] = u[1]*sin(W[1] - W[2])
-    J[2,1] = zero(u[1])
-    J[1,2] = zero(u[1])
-    J[2,2] = u[2]*cos(W[1] + W[2])
-  end
   Random.seed!(seed)
   faug = RODEFunction(f,jac=jac,paramjac=paramjac)
   prob_aug = RODEProblem{false}(faug,u0,tspan,p)
@@ -393,22 +367,20 @@ end
 
   @test du0ReverseDiff ≈ du0 rtol=1e-2
   @test dpReverseDiff ≈ dp' rtol=1e-2
-
 end
 
 
 function f(u,p,t,W)
-  dx = p[1]*u[1]*sin(W[1] - W[2])
-  dy = p[2]*u[2]*cos(W[1] + W[2])
-  return [dx,dy]
+  dx = p[1]*u[1]*sin(W[1])
+  return [dx]
 end
 
 
-dt = 1e-4
-u0 = [1.00;1.00]
+dt = 1e-2
+u0 = [1.00]
 tspan = (0.0,1.0)
 t = tspan[1]:0.1:tspan[2]
-p = [2.0,-2.0]
+p = [2.0]
 
 prob = RODEProblem{false}(f,u0,tspan,p)
 Random.seed!(seed)
@@ -418,8 +390,14 @@ _sol = deepcopy(sol)
 noise_reverse = NoiseGrid(reverse(_sol.t),reverse(_sol.W.W))
 prob_reverse = RODEProblem(f,_sol[end],reverse(tspan),p,noise=noise_reverse)
 sol_reverse = solve(prob_reverse,RandomEM(),dt=dt)
-@test sol(t).u ≈ sol_reverse(t).u rtol=1e-3
+@test sol(t).u ≈ sol_reverse(t).u rtol=1e-2
 @show minimum(sol.u)
+
+# check with forward noise
+noise_forward = DiffEqNoiseProcess.NoiseWrapper(_sol.W)
+prob_forward = RODEProblem(f,_sol(0.0),tspan,p,noise=noise_forward)
+sol_forward = solve(prob_forward,RandomEM(),dt=dt)
+@test sol(t).u ≈ sol_forward(t).u atol=1e-12
 
 # Test if Forward and ReverseMode AD agree.
 Random.seed!(seed)
@@ -428,13 +406,14 @@ du0ReverseDiff,dpReverseDiff = Zygote.gradient((u0,p)->sum(
   ,u0,p)
 Random.seed!(seed)
 dForward = ForwardDiff.gradient((θ)->sum(
-  Array(solve(prob,RandomEM(),dt=dt,u0=θ[1:2],p=θ[3:4],saveat=t)).^2/2)
+  #Array(solve(prob,RandomEM(),dt=dt,u0=θ[1:2],p=θ[3:4],saveat=t)).^2/2)
+  Array(solve(prob,RandomEM(),dt=dt,u0=θ[1:1],p=θ[2:2],saveat=t)).^2/2)
   ,[u0;p])
 
 @info dForward
 
-@test du0ReverseDiff ≈ dForward[1:2]
-@test dpReverseDiff ≈ dForward[3:4]
+@test du0ReverseDiff ≈ dForward[1:1]
+@test dpReverseDiff ≈ dForward[2:2]
 
 # test gradients
 Random.seed!(seed)
@@ -457,29 +436,40 @@ adj_sol_checkpointing = solve(adj_prob_checkpointing, RandomEM(), dt=dt)
 @show adj_sol_checkpointing[end]
 
 
-@test du0ReverseDiff ≈ -adj_sol_checkpointing[end][1:2] rtol=1e-2
-@test dpReverseDiff ≈ adj_sol_checkpointing[end][3:4] rtol=1e-2
+@test du0ReverseDiff ≈ -adj_sol_checkpointing[end][1:1] rtol=1e-2
+@test dpReverseDiff ≈ adj_sol_checkpointing[end][2:2] rtol=1e-2
 
 
-@test du0ReverseDiff ≈ -adj_sol_dense[end][1:2] rtol=1e-2
-@test dpReverseDiff ≈ adj_sol_dense[end][3:4] rtol=1e-2
+@test du0ReverseDiff ≈ -adj_sol_dense[end][1:1] rtol=1e-2
+@test dpReverseDiff ≈ adj_sol_dense[end][2:2] rtol=1e-2
 
 minimum(abs.(adj_sol_checkpointing.W.t - adj_sol_dense.W.t))
+
 
 using Plots
 pl1 = plot(adj_sol_dense, label="Dense")
 plot!(pl1,adj_sol_checkpointing, label="Checkpointing", legend=false)
 
 pl2 = plot(adj_sol_dense.t,hcat(adj_sol_dense-adj_sol_checkpointing ...)')
-
+#savefig(pl1, "sense.png")
 maximum(adj_sol_dense - adj_sol_checkpointing)
 
 adj_prob_backsolve = DiffEqSensitivity.RODEAdjointProblem(sol,BacksolveAdjoint(),dg!,t,nothing)
 adj_sol_backsolve = solve(adj_prob_backsolve, RandomEM(), dt=dt)
 
-plot(getindex.(adj_sol_backsolve(t).u, 3) -getindex.(adj_sol_dense(t).u, 3))
-plot!(getindex.(adj_sol_backsolve(t).u, 4) -getindex.(adj_sol_dense(t).u, 4))
+plot(getindex.(adj_sol_backsolve(t).u, 2) -getindex.(adj_sol_dense(t).u, 2))
+#plot!(getindex.(adj_sol_backsolve(t).u, 4) -getindex.(adj_sol_dense(t).u, 4))
+plot(getindex.(adj_sol_backsolve(t).u, 2) -getindex.(adj_sol_checkpointing(t).u, 2))
+#plot!(getindex.(adj_sol_backsolve(t).u, 4) -getindex.(adj_sol_checkpointing(t).u, 4))
 
 
-plot(getindex.(adj_sol_backsolve(t).u, 3) -getindex.(adj_sol_checkpointing(t).u, 3))
-plot!(getindex.(adj_sol_backsolve(t).u, 4) -getindex.(adj_sol_checkpointing(t).u, 4))
+@test adj_sol_dense.t == adj_sol_checkpointing.t
+@test adj_sol_dense.W.t == adj_sol_checkpointing.W.t
+@test adj_sol_dense.W.W == adj_sol_checkpointing.W.W
+
+
+@test adj_sol_dense.u == adj_sol_checkpointing.u
+
+difference = adj_sol_dense.u - adj_sol_checkpointing.u
+
+@show difference[1:10]

--- a/test/rode.jl
+++ b/test/rode.jl
@@ -129,6 +129,80 @@ end
 
   @test du0ReverseDiff ≈ du0 rtol=1e-2
   @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  ###
+  ## InterpolatingAdjoint
+  ###
+
+  # test gradients with dense solution and no checkpointing
+  Random.seed!(seed)
+  sol = solve(prob,RandomEM(),dt=dt, save_noise=true, dense=true)
+
+  # ReverseDiff
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-1
+
+  # ReverseDiff with compiled tape
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP(true)))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Zygote
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ZygoteVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Tracker
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.TrackerVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = true
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=true))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false and with jac and paramjac
+  function jac(J,u,p,t,W)
+    J[1,1] = p[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = p[2]*cos(W[1] + W[2])
+  end
+
+  function paramjac(J,u,p,t,W)
+    J[1,1] = u[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = u[2]*cos(W[1] + W[2])
+  end
+  Random.seed!(seed)
+  faug = RODEFunction(f,jac=jac,paramjac=paramjac)
+  prob_aug = RODEProblem{true}(faug,u0,tspan,p)
+  sol = solve(prob_aug,RandomEM(),dt=dt, save_noise=true, dense=true)
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
 end
 
 
@@ -244,6 +318,82 @@ end
 
   @test du0ReverseDiff ≈ du0 rtol=1e-2
   @test dpReverseDiff ≈ dp' rtol=1e-2
+
+
+  ###
+  ## InterpolatingAdjoint
+  ###
+
+  # test gradients with dense solution and no checkpointing
+  Random.seed!(seed)
+  sol = solve(prob,RandomEM(),dt=dt, save_noise=true, dense=true)
+
+  # ReverseDiff
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-1
+
+  # ReverseDiff with compiled tape
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP(true)))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Zygote
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ZygoteVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Tracker
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.TrackerVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = true
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=true))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false and with jac and paramjac
+  function jac(J,u,p,t,W)
+    J[1,1] = p[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = p[2]*cos(W[1] + W[2])
+  end
+
+  function paramjac(J,u,p,t,W)
+    J[1,1] = u[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = u[2]*cos(W[1] + W[2])
+  end
+  Random.seed!(seed)
+  faug = RODEFunction(f,jac=jac,paramjac=paramjac)
+  prob_aug = RODEProblem{false}(faug,u0,tspan,p)
+  sol = solve(prob_aug,RandomEM(),dt=dt, save_noise=true, dense=true)
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
 end
 
 

--- a/test/rode.jl
+++ b/test/rode.jl
@@ -288,11 +288,12 @@ dForward = ForwardDiff.gradient((θ)->sum(
 
 # test gradients
 Random.seed!(seed)
-sol = solve(prob,RandomEM(),dt=dt, save_noise=true, saveat=t)
+sol = solve(prob,RandomEM(),dt=dt, save_noise=true)
+
 du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
-  ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=true))
+  ,dt=dt,adaptive=false,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP()))
 
 @test du0ReverseDiff ≈ du0 rtol=1e-2
-@test dpReverseDiff ≈ dp' rtol=1e-2
+@test dpReverseDiff ≈ dp' rtol=1e-1
 
 @info du0, dp'

--- a/test/rode.jl
+++ b/test/rode.jl
@@ -1,0 +1,298 @@
+using StochasticDiffEq
+using DiffEqSensitivity
+using DiffEqNoiseProcess
+using LinearAlgebra, Statistics, Random
+using Zygote, ReverseDiff, ForwardDiff
+using Test
+#using DifferentialEquations
+seed = 12345
+Random.seed!(seed)
+
+function g(u,p,t)
+  sum(u.^2.0/2.0)
+end
+
+function dg!(out,u,p,t,i)
+  (out.=-u)
+end
+
+@testset "noise iip tests" begin
+  function f(du,u,p,t,W)
+    du[1] = p[1]*u[1]*sin(W[1] - W[2])
+    du[2] = p[2]*u[2]*cos(W[1] + W[2])
+    return nothing
+  end
+  dt = 1e-4
+  u0 = [1.00;1.00]
+  tspan = (0.0,5.0)
+  t = tspan[1]:0.1:tspan[2]
+  p = [2.0,-2.0]
+  prob = RODEProblem(f,u0,tspan,p)
+
+  sol = solve(prob,RandomEM(),dt=dt, save_noise=true)
+  # check reversion with usage of Noise Grid
+  _sol = deepcopy(sol)
+  noise_reverse = NoiseGrid(reverse(_sol.t),reverse(_sol.W.W))
+  prob_reverse = RODEProblem(f,_sol[end],reverse(tspan),p,noise=noise_reverse)
+  sol_reverse = solve(prob_reverse,RandomEM(),dt=dt)
+  @test sol.u ≈ reverse(sol_reverse.u) rtol=1e-3
+  @show minimum(sol.u)
+
+  # Test if Forward and ReverseMode AD agree.
+  Random.seed!(seed)
+  du0ReverseDiff,dpReverseDiff = Zygote.gradient((u0,p)->sum(
+    Array(solve(prob,RandomEM(),dt=dt,u0=u0,p=p,saveat=t,sensealg=ReverseDiffAdjoint())).^2/2)
+    ,u0,p)
+  Random.seed!(seed)
+  dForward = ForwardDiff.gradient((θ)->sum(
+    Array(solve(prob,RandomEM(),dt=dt,u0=θ[1:2],p=θ[3:4],saveat=t)).^2/2)
+    ,[u0;p])
+
+  @info dForward
+
+  @test du0ReverseDiff ≈ dForward[1:2]
+  @test dpReverseDiff ≈ dForward[3:4]
+
+  # test gradients
+  Random.seed!(seed)
+  sol = solve(prob,RandomEM(),dt=dt, save_noise=true, saveat=t)
+
+
+  ###
+  ## BacksolveAdjoint
+  ###
+
+  # ReverseDiff
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint())
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  @info du0, dp'
+
+  # ReverseDiff with compiled tape
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP(true)))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.ZygoteVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Tracker
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.TrackerVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = true
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=true))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false and with jac and paramjac
+  function jac(J,u,p,t,W)
+    J[1,1] = p[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = p[2]*cos(W[1] + W[2])
+  end
+
+  function paramjac(J,u,p,t,W)
+    J[1,1] = u[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = u[2]*cos(W[1] + W[2])
+  end
+  Random.seed!(seed)
+  faug = RODEFunction(f,jac=jac,paramjac=paramjac)
+  prob_aug = RODEProblem{true}(faug,u0,tspan,p)
+  sol = solve(prob_aug,RandomEM(),dt=dt, save_noise=true, saveat=t)
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+end
+
+
+@testset "noise oop tests" begin
+  function f(u,p,t,W)
+    dx = p[1]*u[1]*sin(W[1] - W[2])
+    dy = p[2]*u[2]*cos(W[1] + W[2])
+    return [dx,dy]
+  end
+  dt = 1e-4
+  u0 = [1.00;1.00]
+  tspan = (0.0,5.0)
+  t = tspan[1]:0.1:tspan[2]
+  p = [2.0,-2.0]
+  prob = RODEProblem{false}(f,u0,tspan,p)
+
+  sol = solve(prob,RandomEM(),dt=dt, save_noise=true)
+  # check reversion with usage of Noise Grid
+  _sol = deepcopy(sol)
+  noise_reverse = NoiseGrid(reverse(_sol.t),reverse(_sol.W.W))
+  prob_reverse = RODEProblem(f,_sol[end],reverse(tspan),p,noise=noise_reverse)
+  sol_reverse = solve(prob_reverse,RandomEM(),dt=dt)
+  @test sol.u ≈ reverse(sol_reverse.u) rtol=1e-3
+  @show minimum(sol.u)
+
+  # Test if Forward and ReverseMode AD agree.
+  Random.seed!(seed)
+  du0ReverseDiff,dpReverseDiff = Zygote.gradient((u0,p)->sum(
+    Array(solve(prob,RandomEM(),dt=dt,u0=u0,p=p,saveat=t,sensealg=ReverseDiffAdjoint())).^2/2)
+    ,u0,p)
+  Random.seed!(seed)
+  dForward = ForwardDiff.gradient((θ)->sum(
+    Array(solve(prob,RandomEM(),dt=dt,u0=θ[1:2],p=θ[3:4],saveat=t)).^2/2)
+    ,[u0;p])
+
+  @info dForward
+
+  @test du0ReverseDiff ≈ dForward[1:2]
+  @test dpReverseDiff ≈ dForward[3:4]
+
+  # test gradients
+  Random.seed!(seed)
+  sol = solve(prob,RandomEM(),dt=dt, save_noise=true, saveat=t)
+
+  ###
+  ## BacksolveAdjoint
+  ###
+
+  # ReverseDiff
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  @info du0, dp'
+
+  # ReverseDiff with compiled tape
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.ReverseDiffVJP(true)))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Zygote
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.ZygoteVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # Tracker
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.TrackerVJP()))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = true
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=true))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+
+  # isautojacvec = false and with jac and paramjac
+  function jac(J,u,p,t,W)
+    J[1,1] = p[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = p[2]*cos(W[1] + W[2])
+  end
+
+  function paramjac(J,u,p,t,W)
+    J[1,1] = u[1]*sin(W[1] - W[2])
+    J[2,1] = zero(u[1])
+    J[1,2] = zero(u[1])
+    J[2,2] = u[2]*cos(W[1] + W[2])
+  end
+  Random.seed!(seed)
+  faug = RODEFunction(f,jac=jac,paramjac=paramjac)
+  prob_aug = RODEProblem{false}(faug,u0,tspan,p)
+  sol = solve(prob_aug,RandomEM(),dt=dt, save_noise=true, saveat=t)
+  du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+    ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=false))
+
+  @test du0ReverseDiff ≈ du0 rtol=1e-2
+  @test dpReverseDiff ≈ dp' rtol=1e-2
+end
+
+
+function f(u,p,t,W)
+  dx = p[1]*u[1]*sin(W[1] - W[2])
+  dy = p[2]*u[2]*cos(W[1] + W[2])
+  return [dx,dy]
+end
+
+
+dt = 1e-4
+u0 = [1.00;1.00]
+tspan = (0.0,5.0)
+t = tspan[1]:0.1:tspan[2]
+p = [2.0,-2.0]
+
+prob = RODEProblem{false}(f,u0,tspan,p)
+
+sol = solve(prob,RandomEM(),dt=dt, save_noise=true)
+# check reversion with usage of Noise Grid
+_sol = deepcopy(sol)
+noise_reverse = NoiseGrid(reverse(_sol.t),reverse(_sol.W.W))
+prob_reverse = RODEProblem(f,_sol[end],reverse(tspan),p,noise=noise_reverse)
+sol_reverse = solve(prob_reverse,RandomEM(),dt=dt)
+@test sol.u ≈ reverse(sol_reverse.u) rtol=1e-3
+@show minimum(sol.u)
+
+# Test if Forward and ReverseMode AD agree.
+Random.seed!(seed)
+du0ReverseDiff,dpReverseDiff = Zygote.gradient((u0,p)->sum(
+  Array(solve(prob,RandomEM(),dt=dt,u0=u0,p=p,saveat=t,sensealg=ReverseDiffAdjoint())).^2/2)
+  ,u0,p)
+Random.seed!(seed)
+dForward = ForwardDiff.gradient((θ)->sum(
+  Array(solve(prob,RandomEM(),dt=dt,u0=θ[1:2],p=θ[3:4],saveat=t)).^2/2)
+  ,[u0;p])
+
+@info dForward
+
+@test du0ReverseDiff ≈ dForward[1:2]
+@test dpReverseDiff ≈ dForward[3:4]
+
+# test gradients
+Random.seed!(seed)
+sol = solve(prob,RandomEM(),dt=dt, save_noise=true, saveat=t)
+du0, dp = adjoint_sensitivities(sol,RandomEM(),dg!,Array(t)
+  ,dt=dt,adaptive=false,sensealg=BacksolveAdjoint(autojacvec=true))
+
+@test du0ReverseDiff ≈ du0 rtol=1e-2
+@test dpReverseDiff ≈ dp' rtol=1e-2
+
+@info du0, dp'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,6 +50,7 @@ if GROUP == "All" || GROUP == "SDE2"
 end
 
 if GROUP == "All" || GROUP == "SDE3"
+    @time @safetestset "RODE Tests" begin include("rode.jl") end
     @time @safetestset "SDE Ito Conversion Tests" begin include("sde_transformation_test.jl") end
     @time @safetestset "SDE Ito Scalar Noise" begin include("sde_scalar_ito.jl") end
 end

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -504,7 +504,7 @@ end
     ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
   @test res_sde_u0 ≈ res_sde_u02 atol = 1e-8
-  @test res_sde_p ≈ res_sde_p2 atol = 1e-8
+  @test res_sde_p ≈ res_sde_p2 atol = 5e-8
 
   @show res_sde_u0
 

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -492,7 +492,6 @@ end
   @test adj_soloop[end] ≈  adj_sol[end]  rtol=1e-8
 
 
-
   # InterpolatingAdjoint
 
   res_sde_u0, res_sde_p = adjoint_sensitivities(soloop,EulerHeun(),dg!,tarray
@@ -502,8 +501,8 @@ end
   res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
     ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
-  @test res_sde_u0 ≈ res_sde_u02 atol = 1e-14
-  @test res_sde_p ≈ res_sde_p2 atol = 5e-14
+  @test res_sde_u0 ≈ res_sde_u02 atol = 1e-9
+  @test res_sde_p ≈ res_sde_p2 atol = 1e-9
 
   @show res_sde_u0
 
@@ -517,7 +516,7 @@ end
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(noisemixing=true, checkpointing=true),dg!,tarray, nothing)
   adj_sol = solve(adjprob,EulerHeun(); dt=dtmix, adaptive=false,tstops=soloop.t)
 
-  @test adj_soloop[end] ≈ adj_sol[end]  rtol=1e-14
+  @test adj_soloop[end] ≈ adj_sol[end]  rtol=1e-8
 
 
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(noisemixing=true, checkpointing=false),dg!,tarray, nothing)

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -503,7 +503,7 @@ end
     ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
   @test res_sde_u0 ≈ res_sde_u02 atol = 1e-14
-  @test res_sde_p ≈ res_sde_p2 atol = 1e-14
+  @test res_sde_p ≈ res_sde_p2 atol = 5e-14
 
   @show res_sde_u0
 
@@ -517,7 +517,7 @@ end
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(noisemixing=true, checkpointing=true),dg!,tarray, nothing)
   adj_sol = solve(adjprob,EulerHeun(); dt=dtmix, adaptive=false,tstops=soloop.t)
 
-  @test adj_soloop[end] ≈  adj_sol[end]  rtol=1e-15
+  @test adj_soloop[end] ≈ adj_sol[end]  rtol=1e-14
 
 
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(noisemixing=true, checkpointing=false),dg!,tarray, nothing)

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -450,11 +450,13 @@ end
   Random.seed!(seed)
   prob = SDEProblem(f_mixing!,g_mixing!,u₀,trange,p)
   soltsave = collect(trange[1]:dtmix:trange[2])
-  sol = solve(prob, EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave )
+  sol = solve(prob, EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave)
 
   Random.seed!(seed)
   proboop = SDEProblem(f_mixing,g_mixing,u₀,trange,p)
   soloop = solve(proboop,EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave)
+
+  @test sol.u ≈ soloop.u atol = 1e-14
 
 
   # BacksolveAdjoint
@@ -501,8 +503,8 @@ end
   res_sde_u02, res_sde_p2 = adjoint_sensitivities(sol,EulerHeun(),dg!,tarray
     ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
-  @test res_sde_u0 ≈ res_sde_u02 atol = 1e-9
-  @test res_sde_p ≈ res_sde_p2 atol = 1e-9
+  @test res_sde_u0 ≈ res_sde_u02 atol = 1e-8
+  @test res_sde_p ≈ res_sde_p2 atol = 1e-8
 
   @show res_sde_u0
 

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -359,7 +359,7 @@ end
       ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
   @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-5)
-  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-5) # would pass with 1e-4 but last noise value is off
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-5) # would pass with 1e-4 but last noise value is off
 
   @info res_sde_pa
 
@@ -375,7 +375,7 @@ end
     ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noise=false, noisemixing=true))
 
   @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-5)
-  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-5)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-5)
 
   @info res_sde_pa
 
@@ -383,7 +383,7 @@ end
       ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noise=DiffEqSensitivity.ReverseDiffNoise(),noisemixing=true))
 
   @test isapprox(res_sde_u0a, res_sde_u0, rtol=1e-5)
-  @test_broken isapprox(res_sde_pa, res_sde_p, rtol=1e-5)
+  @test isapprox(res_sde_pa, res_sde_p, rtol=1e-5)
 
   @info res_sde_pa
 
@@ -503,7 +503,7 @@ end
     ,dt=dtmix,adaptive=false,sensealg=InterpolatingAdjoint(noisemixing=true))
 
   @test res_sde_u0 ≈ res_sde_u02 atol = 1e-14
-  @test_broken res_sde_p ≈ res_sde_p2 atol = 1e-14
+  @test res_sde_p ≈ res_sde_p2 atol = 1e-14
 
   @show res_sde_u0
 
@@ -517,11 +517,11 @@ end
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(noisemixing=true, checkpointing=true),dg!,tarray, nothing)
   adj_sol = solve(adjprob,EulerHeun(); dt=dtmix, adaptive=false,tstops=soloop.t)
 
-  @test_broken adj_soloop[end] ≈  adj_sol[end]  rtol=1e-15
+  @test adj_soloop[end] ≈  adj_sol[end]  rtol=1e-15
 
 
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(noisemixing=true, checkpointing=false),dg!,tarray, nothing)
   adj_sol = solve(adjprob,EulerHeun(); dt=dtmix, adaptive=false,tstops=soloop.t)
 
-  @test_broken adj_soloop[end] ≈  adj_sol[end]  rtol=1e-8
+  @test adj_soloop[end] ≈  adj_sol[end]  rtol=1e-8
 end

--- a/test/sde_scalar_ito.jl
+++ b/test/sde_scalar_ito.jl
@@ -135,8 +135,8 @@ resp = [resp1, resp2]
 @test isapprox(resp, gs_p', atol=1e-2) # exact vs ito adjoint
 @test isapprox(res_p, gs_p, atol=1e-2) # strat vs ito adjoint
 @test isapprox(gs_p', res_forward, atol=1e-2) # ito adjoint vs forward
-@test isapprox(resp, res_p', rtol=1e-5) # exact vs strat adjoint
-@test isapprox(resp, res_forward, rtol=1e-5) # exact vs forward
+@test isapprox(resp, res_p', rtol=2e-5) # exact vs strat adjoint
+@test isapprox(resp, res_forward, rtol=2e-5) # exact vs forward
 @test isapprox(res_reverse, res_forward, rtol=1e-12) # reverse vs forward
 
 # tests for initial state gradients

--- a/test/sde_transformation_test.jl
+++ b/test/sde_transformation_test.jl
@@ -28,11 +28,11 @@ transformed_function = StochasticTransformedFunction(sol,sol.prob.f,sol.prob.g)
 du2 = transformed_function(u,p,tspan[2])
 
 #@test du[1] == (p[1]*u[1]-p[2]^2*u[1])
-@test du2[1] == (p[1]*u[1]-p[2]^2*u[1])
+@test isapprox(du2[1], (p[1]*u[1]-p[2]^2*u[1]), atol=1e-15)
 #@test du2 == du
 transformed_function = StochasticTransformedFunction(sol,sol.prob.f,sol.prob.g,(u,p,t)->p[2]^2*u)
 du2 = transformed_function(u,p,tspan[2])
-@test du2[1] == (p[1]*u[1]-p[2]^2*u[1])
+@test isapprox(du2[1], (p[1]*u[1]-p[2]^2*u[1]), atol=1e-15)
 
 linear_analytic_strat(u0,p,t,W) = @.(u0*exp((p[1])*t+p[2]*W))
 


### PR DESCRIPTION
Needs: 
https://github.com/SciML/StochasticDiffEq.jl/pull/409
https://github.com/SciML/DiffEqNoiseProcess.jl/pull/88

- implements the  `BacksolveAdjoint` and `InterpolatingAdjoint` for random ordinary differential equations.  
- use of reverse() function to support `NoiseGrid`s and `NoiseProcess`es from forward simulation. 

- biggest obstacle is that `save_noise=true` doesn't save the full noise process if `saveat=t` is used