### PR TITLE
add additive noise downstream test for diffeqflux

### DIFF
--- a/test/downstream/sde_neural.jl
+++ b/test/downstream/sde_neural.jl
@@ -204,5 +204,5 @@ end
         false
     end
     res1 = @time DiffEqFlux.sciml_train((p) -> loss(p,prob, LambaEM()), p_nn, ADAM(0.1), cb = callback, maxiters=5)
-    res2 = @time DiffEqFlux.sciml_train((p) -> loss(p,prob, SOSRA()), p_nn, ADAM(0.1), cb = callback, maxiters=5)
+    res2 = @time DiffEqFlux.sciml_train((p) -> loss(p,prob, SOSRI()), p_nn, ADAM(0.1), cb = callback, maxiters=5)
 end


### PR DESCRIPTION
Test case from: https://discourse.julialang.org/t/diffeqflux-sosra2-algorithm-backsolveadjoint-gives-an-error/61237
and solved via https://github.com/SciML/DiffEqNoiseProcess.jl/pull/93 .
I added an `@ time ` for `LambaEM()` and `SOSRA()`. The `SOSRA` seems to take very long..
