### PR TITLE
allow for changes of `p` in callbacks

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -43,11 +43,11 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
 
   if haskey(kwargs, :callback) || haskey(prob.kwargs,:callback)
     if haskey(kwargs, :callback) && haskey(prob.kwargs,:callback)
-      cb = track_callbacks(CallbackSet(prob.kwargs[:callback],kwargs[:callback]),prob.tspan[1],prob.u0)
+      cb = track_callbacks(CallbackSet(prob.kwargs[:callback],kwargs[:callback]),prob.tspan[1],prob.u0,prob.p)
     elseif haskey(prob.kwargs,:callback)
-      cb = track_callbacks(CallbackSet(prob.kwargs[:callback]),prob.tspan[1],prob.u0)
+      cb = track_callbacks(CallbackSet(prob.kwargs[:callback]),prob.tspan[1],prob.u0,prob.p)
     else #haskey(kwargs,:callback)
-      cb = track_callbacks(CallbackSet(kwargs[:callback]),prob.tspan[1],prob.u0)
+      cb = track_callbacks(CallbackSet(kwargs[:callback]),prob.tspan[1],prob.u0,prob.p)
     end
     _prob = remake(prob,u0=u0,p=p,callback=cb)
   else

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -378,7 +378,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::SensitivityFunction, isautojacvec::R
   end
   W !== nothing && ReverseDiff.unseed!(tW)
   ReverseDiff.value!(tu, y)
-  ReverseDiff.value!(tp, prob.p)
+  ReverseDiff.value!(tp, p)
   if !(prob isa DiffEqBase.SteadyStateProblem)
     ReverseDiff.value!(tt, [t])
   end

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -204,7 +204,7 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
                        atol=sensealg.abstol,rtol=sensealg.reltol)
     else
       res = zero(integrand.p)'
-      for i in 1:length(t)-1
+      for i in length(t)-1:-1:1
         res .+= quadgk(integrand,t[i],t[i+1],
                        atol=sensealg.abstol,rtol=sensealg.reltol)[1]
         if t[i]==t[i+1]

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -191,7 +191,7 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
   dgdu, dgdp = dg isa Tuple ? dg : (dg, nothing)
   adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dgdu,callback)
   adj_sol = solve(adj_prob,alg;abstol=abstol,reltol=reltol,
-                               save_everystep=true,save_start=true,kwargs...)                          
+                               save_everystep=true,save_start=true,kwargs...)
 
   p = sol.prob.p
   if p === nothing || p === DiffEqBase.NullParameters()
@@ -207,6 +207,29 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
       for i in 1:length(t)-1
         res .+= quadgk(integrand,t[i],t[i+1],
                        atol=sensealg.abstol,rtol=sensealg.reltol)[1]
+        if t[i]==t[i+1]
+          for cb in callback.discrete_callbacks
+            if t[i] ∈ cb.affect!.event_times
+              function wp(dp,p,u,t)
+                fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t)
+                cb.affect!.affect!(fakeinteg)
+                dp .= fakeinteg.p
+              end
+
+              _p = similar(integrand.p, size(integrand.p))
+              wp(_p,integrand.p,integrand.y,t[i])
+
+              if _p != integrand.p
+                fakeSp = CallbackSensitivityFunction(wp,sensealg,adj_prob.f.f.diffcache,sol.prob)
+                #vjp with Jacobin given by dw/dp before event and vector given by grad
+                vecjacobian!(res, integrand.p, res, integrand.y, t[i], fakeSp;
+                                    dgrad=nothing, dy=nothing)
+                integrand = update_p_integrand(integrand,_p)
+              end
+            end
+          end
+
+        end
       end
       if t[1] != sol.prob.tspan[1]
         res .+= quadgk(integrand,sol.prob.tspan[1],t[1],
@@ -215,4 +238,9 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
     end
     return -adj_sol[end], res
   end
+end
+
+function update_p_integrand(integrand::AdjointSensitivityIntegrand,p)
+  @unpack sol, adj_sol, y, λ, pf, f_cache, pJ, paramjac_config, sensealg, dgdp_cache, dgdp = integrand
+  AdjointSensitivityIntegrand(sol,adj_sol,p,y,λ,pf,f_cache,pJ,paramjac_config,sensealg,dgdp_cache,dgdp)
 end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -338,7 +338,7 @@ function test_continuous_callback(cb, g, dg!)
   @test dp1 ≈ dp2
   @test dp1 ≈ dp3
   @test dp1 ≈ dp3c
-  @test dp1 ≈ dp4
+  @test dp1 ≈ dp4 rtol=1e-7
 
   @test du02 ≈ dstuff[1:2]
   @test dp2 ≈ dstuff[3:6]

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -84,7 +84,7 @@ function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing)
   @test dp1 ≈ dp2
   @test dp1 ≈ dp3
   @test dp1 ≈ dp3c
-  @test dp1 ≈ dp4
+  @test dp1 ≈ dp4 rtol=1e-7
 
   @test du02 ≈ dstuff[1:2]
   @test dp2 ≈ dstuff[3:6]

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -5,7 +5,7 @@ abstol=1e-12
 reltol=1e-12
 savingtimes=0.5
 
-function test_discrete_callback(cb, tstops, g, dg!)
+function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing)
   function fiip(du,u,p,t)
     du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
     du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
@@ -42,9 +42,15 @@ function test_discrete_callback(cb, tstops, g, dg!)
     (u0,p)->g(solve(proboop,Tsit5(),u0=u0,p=p,callback=cb,tstops=tstops,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=BacksolveAdjoint(checkpointing=false))),
     u0,p)
 
-  du02,dp2 = Zygote.gradient(
+  if cboop === nothing
+    du02,dp2 = Zygote.gradient(
     (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,tstops=tstops,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=ReverseDiffAdjoint()))
     ,u0,p)
+  else
+    du02,dp2 = Zygote.gradient(
+      (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cboop,tstops=tstops,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=ReverseDiffAdjoint()))
+      ,u0,p)
+  end
 
   du03,dp3 = Zygote.gradient(
     (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,tstops=tstops,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=InterpolatingAdjoint(checkpointing=true))),
@@ -450,9 +456,12 @@ end
         @testset "parameter changing callback at single time point" begin
           condition(u,t,integrator) = t == 5.1
           affect!(integrator) = (integrator.p .= 2*integrator.p .- 0.5)
+          affect(integrator) = (integrator.p = 2*integrator.p .- 0.5)
+          cb = DiscreteCallback(condition,affect!)
+          cboop = DiscreteCallback(condition,affect)
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.1]
-          test_discrete_callback(cb,tstops,g,dg!)
+          test_discrete_callback(cb,tstops,g,dg!,cboop)
         end
       end
       @testset "MSE loss function" begin
@@ -503,9 +512,11 @@ end
         @testset "parameter changing callback at single time point" begin
           condition(u,t,integrator) = t == 5.1
           affect!(integrator) = (integrator.p .= 2*integrator.p .- 0.5)
+          affect(integrator) = (integrator.p = 2*integrator.p .- 0.5)
           cb = DiscreteCallback(condition,affect!)
+          cboop = DiscreteCallback(condition,affect)
           tstops=[5.1]
-          test_discrete_callback(cb,tstops,g,dg!)
+          test_discrete_callback(cb,tstops,g,dg!,cboop)
         end
       end
   	end


### PR DESCRIPTION
To handle changes in `p`, one needs to add an additional vjp. That consists of `grad` (gradient of the loss function with respect to the parameter) as the vector and the Jacobian of the callback function with respect to the parameters before the callback. Slightly abusing the `vecjacobian!` interface, we may use:
```julia
function wp(dp,p,u,t)
    fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t)
    cb.affect!.affect!(fakeinteg)
    dp .= fakeinteg.p
end

fakeSp = CallbackSensitivityFunction(wp,sensealg,S.diffcache,integrator.sol.prob)
#vjp with Jacobin given by dw/dp before event and vector given by grad
vecjacobian!(dgrad, integrator.p, grad, y, integrator.t, fakeSp;
                                  dgrad=nothing, dy=nothing)
grad .= dgrad       
```

For `QuadratureAdjoint`, we need to accumulate/update the grads during the integration for `p` when duplicate times are reached. (There is still an error in the current version of the code as `dp` doesn't come out correctly..)
For `InterpolatingAdjoint` with  checkpointing,  one needs to do a check if a callback might have occured in a given time interval. If that is the case we need to search for the left-most callback time and use the associated stored left-limit of the callback for the checkpointed solution. 

I have not yet figured out how `ReverseDiffAdjoint` could be made compatible with 
```julia
affect!(integrator) = (integrator.p .= 2*integrator.p .- 0.5)
```
.. it fails with "TrackedArrays do not support `setindex`". It works with 
```julia
affect!(integrator) = (integrator.p = 2*integrator.p .- 0.5) # no inplace
```
though. For `integrator.u` it works both ways. Could someone point me to the trick? 