### PR TITLE
Concrete_solve dispatch for LSS methods

### DIFF
--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -36,7 +36,8 @@ export ODEForwardSensitivityFunction, ODEForwardSensitivityProblem, SensitivityF
        ODEAdjointSensitivityProblem, ODEAdjointProblem, AdjointSensitivityIntegrand,
        SDEAdjointProblem, RODEAdjointProblem, SensitivityAlg,
        adjoint_sensitivities, adjoint_sensitivities_u0,
-       ForwardLSSProblem, AdjointLSSProblem
+       ForwardLSSProblem, AdjointLSSProblem,
+       shadow_forward, shadow_adjoint
 
 export BacksolveAdjoint, QuadratureAdjoint, InterpolatingAdjoint,
        TrackerAdjoint, ZygoteAdjoint, ReverseDiffAdjoint,

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -424,6 +424,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
                                  u0,p,args...;save_start=true,save_end=true,
                                  saveat = eltype(prob.tspan)[],
                                  save_idxs = nothing,
+                                 t0skip=zero(eltype(prob.tspan)), t1skip=zero(eltype(prob.tspan)),
                                  kwargs...)
 
   if haskey(kwargs, :callback) || haskey(prob.kwargs,:callback)
@@ -509,10 +510,10 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
 
     if sensealg isa ForwardLSS
       lss_problem = ForwardLSSProblem(sol, sensealg, g, df)
-      dp = __solve(lss_problem)
+      dp = __solve(lss_problem;  t0skip=t0skip, t1skip=t1skip)
     else
       adjointlss_problem = AdjointLSSProblem(sol, sensealg, g, df)
-      dp = __solve(adjointlss_problem)
+      dp = __solve(adjointlss_problem;  t0skip=t0skip, t1skip=t1skip)
     end
 
     (nothing,nothing,nothing,dp,nothing,ntuple(_->nothing, length(args))...)

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -432,7 +432,6 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     _prob = remake(prob,u0=u0,p=p)
   end
 
-  @show kwargs
   if haskey(kwargs, :g)
     g = kwargs[:g]
   else
@@ -443,7 +442,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     error("Time dilation needs explicit knowledge of g. Either pass `g` as a kwarg or use ForwardLSS with windowing")
   end
 
-  sol = solve(_prob,alg,args...;save_noise=true,save_start=save_start,save_end=save_end,saveat=saveat,kwargs...)
+  sol = solve(_prob,alg,args...;save_start=save_start,save_end=save_end,saveat=saveat,kwargs...)
 
   if saveat isa Number
     if _prob.tspan[2] > _prob.tspan[1]

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -510,10 +510,10 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
 
     if sensealg isa ForwardLSS
       lss_problem = ForwardLSSProblem(sol, sensealg, g, df)
-      dp = __solve(lss_problem;  t0skip=t0skip, t1skip=t1skip)
+      dp = shadow_forward(lss_problem;  t0skip=t0skip, t1skip=t1skip)
     else
       adjointlss_problem = AdjointLSSProblem(sol, sensealg, g, df)
-      dp = __solve(adjointlss_problem;  t0skip=t0skip, t1skip=t1skip)
+      dp = shadow_adjoint(adjointlss_problem;  t0skip=t0skip, t1skip=t1skip)
     end
 
     (nothing,nothing,nothing,dp,nothing,ntuple(_->nothing, length(args))...)

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -419,6 +419,108 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,sensealg::ReverseDiffAdjoin
 end
 
 
+function DiffEqBase._concrete_solve_adjoint(prob,alg,
+                                 sensealg::Union{AdjointLSS,ForwardLSS},
+                                 u0,p,args...;save_start=true,save_end=true,
+                                 saveat = eltype(prob.tspan)[],
+                                 save_idxs = nothing,
+                                 kwargs...)
+
+  if haskey(kwargs, :callback) || haskey(prob.kwargs,:callback)
+    error("Sensitivity analysis based on Least Squares Shadowing is not compatible with callbacks. Please select another `sensealg`.")
+  else
+    _prob = remake(prob,u0=u0,p=p)
+  end
+
+  @show kwargs
+  if haskey(kwargs, :g)
+    g = kwargs[:g]
+  else
+    g = nothing
+  end
+
+  if (sensealg.alpha isa Number && g===nothing)
+    error("Time dilation needs explicit knowledge of g. Either pass `g` as a kwarg or use ForwardLSS with windowing")
+  end
+
+  sol = solve(_prob,alg,args...;save_noise=true,save_start=save_start,save_end=save_end,saveat=saveat,kwargs...)
+
+  if saveat isa Number
+    if _prob.tspan[2] > _prob.tspan[1]
+      ts = _prob.tspan[1]:convert(typeof(_prob.tspan[2]),abs(saveat)):_prob.tspan[2]
+    else
+      ts = _prob.tspan[2]:convert(typeof(_prob.tspan[2]),abs(saveat)):_prob.tspan[1]
+    end
+     _out = sol(ts)
+    out = if save_idxs === nothing
+      out = DiffEqBase.sensitivity_solution(sol,_out.u,sol.t)
+    else
+      out = DiffEqBase.sensitivity_solution(sol,[_out[i][save_idxs] for i in 1:length(_out)],ts)
+    end
+    # only_end
+    (length(ts) == 1 && ts[1] == _prob.tspan[2]) && error("Sensitivity analysis based on Least Squares Shadowing requires a long-time averaged quantity.")
+  elseif isempty(saveat)
+    no_start = !save_start
+    no_end = !save_end
+    sol_idxs = 1:length(sol)
+    no_start && (sol_idxs = sol_idxs[2:end])
+    no_end && (sol_idxs = sol_idxs[1:end-1])
+    only_end = length(sol_idxs) <= 1
+    _u = sol.u[sol_idxs]
+    u = save_idxs === nothing ? _u : [x[save_idxs] for x in _u]
+    ts = sol.t[sol_idxs]
+    out = DiffEqBase.sensitivity_solution(sol,u,ts)
+  else
+    _saveat = saveat isa Array ? sort(saveat) : saveat # for minibatching
+    _saveat = eltype(_saveat) <: typeof(prob.tspan[2]) ? convert.(typeof(_prob.tspan[2]),_saveat) : _saveat
+    ts = _saveat
+    _out = sol(ts)
+
+    out = if save_idxs === nothing
+      out = DiffEqBase.sensitivity_solution(sol,_out.u,ts)
+    else
+      out = DiffEqBase.sensitivity_solution(sol,[_out[i][save_idxs] for i in 1:length(_out)],ts)
+    end
+    # only_end
+    (length(ts) == 1 && ts[1] == _prob.tspan[2]) && error("Sensitivity analysis based on Least Squares Shadowing requires a long-time averaged quantity.")
+  end
+
+  _save_idxs = save_idxs === nothing ? Colon() : save_idxs
+
+  function adjoint_sensitivity_backpass(Δ)
+    function df(_out, u, p, t, i)
+      if typeof(Δ) <: AbstractArray{<:AbstractArray} || typeof(Δ) <: DESolution
+        if typeof(_save_idxs) <: Number
+          _out[_save_idxs] = -Δ[i][_save_idxs]
+        elseif _save_idxs isa Colon
+          vec(_out) .= -vec(Δ[i])
+        else
+          vec(@view(_out[_save_idxs])) .= -vec(Δ[i][_save_idxs])
+        end
+      else
+        if typeof(_save_idxs) <: Number
+          _out[_save_idxs] = -adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[_save_idxs, i])
+        elseif _save_idxs isa Colon
+          vec(_out) .= -vec(adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
+        else
+          vec(@view(_out[_save_idxs])) .= -vec(adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
+        end
+      end
+    end
+
+    if sensealg isa ForwardLSS
+      lss_problem = ForwardLSSProblem(sol, sensealg, g, df)
+      dp = __solve(lss_problem)
+    else
+      adjointlss_problem = AdjointLSSProblem(sol, sensealg, g, df)
+      dp = __solve(adjointlss_problem)
+    end
+
+    (nothing,nothing,nothing,dp,nothing,ntuple(_->nothing, length(args))...)
+  end
+  out, adjoint_sensitivity_backpass
+end
+
 function DiffEqBase._concrete_solve_adjoint(prob::Union{NonlinearProblem,SteadyStateProblem},
                                             alg,sensealg::SteadyStateAdjoint,
                                             u0,p,args...;save_idxs = nothing, kwargs...)

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -292,11 +292,11 @@ function b!(b, prob::ForwardLSSProblem)
   return nothing
 end
 
-function __solve(prob::ForwardLSSProblem; t0skip=zero(prob.Δt), t1skip=zero(prob.Δt))
-  __solve(prob,prob.sensealg,prob.sensealg.alpha,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem; t0skip=zero(prob.Δt), t1skip=zero(prob.Δt))
+  shadow_forward(prob,prob.sensealg,prob.sensealg.alpha,t0skip,t1skip)
 end
 
-function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0skip,t1skip)
   @unpack sol, S, F, window, Δt, diffcache, b, w, v, η, res, g, g0, dg, umid = prob
   @unpack wBinv, wEinv, B, E = S
   @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config, numparams, numindvar, uf = diffcache
@@ -363,7 +363,7 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0sk
   return res
 end
 
-function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowing,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowing,t0skip,t1skip)
   @unpack sol, S, F, window, Δt, diffcache, b, w, v, dg, res = prob
   @unpack wBinv, B = S
   @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config, numparams, numindvar, uf = diffcache
@@ -410,7 +410,7 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowin
   return res
 end
 
-function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Cos2Windowing,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Cos2Windowing,t0skip,t1skip)
     @unpack sol, S, F, window, Δt, diffcache, b, w, v, dg, res = prob
     @unpack wBinv, B = S
     @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config, numparams, numindvar, uf = diffcache
@@ -580,11 +580,11 @@ function wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
   return nothing
 end
 
-function __solve(prob::AdjointLSSProblem; t0skip=zero(prob.Δt), t1skip=zero(prob.Δt))
-  __solve(prob,prob.sensealg,prob.sensealg.alpha,t0skip,t1skip)
+function shadow_adjoint(prob::AdjointLSSProblem; t0skip=zero(prob.Δt), t1skip=zero(prob.Δt))
+  shadow_adjoint(prob,prob.sensealg,prob.sensealg.alpha,t0skip,t1skip)
 end
 
-function __solve(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0skip,t1skip)
+function shadow_adjoint(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0skip,t1skip)
   @unpack sol, S, F, Δt, diffcache, h, b, wa, res, g, g0, dg, umid = prob
   @unpack wBinv, B, E = S
   @unpack dg_val, pgpp, pgpp_config, numparams, numindvar, uf, f, f_cache, pJ, pf, paramjac_config = diffcache

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -79,8 +79,6 @@ function LSSSensitivityFunction(sensealg,f,analytic,jac,jac_prototype,sparsity,p
     dg_val[2] .= false
   end
 
-
-
   LSSSensitivityFunction{isinplace(f),typeof(f),typeof(analytic),
                              typeof(jac),typeof(jac_prototype),typeof(sparsity),
                              typeof(paramjac),
@@ -98,7 +96,7 @@ end
 
 
 struct ForwardLSSProblem{A,C,solType,dtType,umidType,dudtType,SType,Ftype,bType,ηType,wType,vType,windowType,
-    ΔtType,G0,G,resType}
+    ΔtType,G0,G,DG,resType}
   sensealg::A
   diffcache::C
   sol::solType
@@ -116,6 +114,7 @@ struct ForwardLSSProblem{A,C,solType,dtType,umidType,dudtType,SType,Ftype,bType,
   Nt::Int
   g0::G0
   g::G
+  dg::DG
   res::resType
 end
 
@@ -177,8 +176,8 @@ function ForwardLSSProblem(sol, sensealg::ForwardLSS, g, dg = nothing;
   ForwardLSSProblem{typeof(sensealg),typeof(sense),typeof(sol),typeof(dt),
     typeof(umid),typeof(dudt),
     typeof(S),typeof(F),typeof(b),typeof(η),typeof(w),typeof(v),typeof(window),typeof(Δt),
-    typeof(g0),typeof(g),typeof(res)}(sensealg,sense,sol,dt,umid,dudt,S,F,b,η,w,v,window,Δt,Nt,g0,g,
-    res)
+    typeof(g0),typeof(g),typeof(dg),typeof(res)}(sensealg,sense,sol,dt,umid,dudt,S,F,b,η,w,v,
+    window,Δt,Nt,g0,g,dg,res)
 end
 
 function LSSSchur(dt,u0,numindvar,Nt,Ndt,alpha)
@@ -298,7 +297,7 @@ function __solve(prob::ForwardLSSProblem; t0skip=zero(prob.Δt), t1skip=zero(pro
 end
 
 function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0skip,t1skip)
-  @unpack sol, S, F, window, Δt, diffcache, b, w, v, η, res, g, g0, umid = prob
+  @unpack sol, S, F, window, Δt, diffcache, b, w, v, η, res, g, g0, dg, umid = prob
   @unpack wBinv, wEinv, B, E = S
   @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config, numparams, numindvar, uf = diffcache
 
@@ -327,14 +326,26 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0sk
     for (j,u) in enumerate(ures)
       vtmp = @view v[(n0+j-2)*numindvar+1:j*numindvar]
       #  final gradient result for ith parameter
-      if dg_val isa Tuple
-        DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg,pgpu_config)
-        DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg,pgpp_config)
-        res[i] += dot(dg_val[1],vtmp)
-        res[i] += dg_val[2][i]
+      if dg===nothing
+        if dg_val isa Tuple
+          DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg,pgpu_config)
+          DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg,pgpp_config)
+          res[i] += dot(dg_val[1],vtmp)
+          res[i] += dg_val[2][i]
+        else
+          DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg,pgpu_config)
+          res[i] += dot(dg_val,vtmp)
+        end
       else
-        DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg,pgpu_config)
-        res[i] += dot(dg_val,vtmp)
+        if dg_val isa Tuple
+          dg[1](dg_val[1],u,uf.p,nothing,j)
+          dg[2](dg_val[2],u,uf.p,nothing,j)
+          res[i] += dot(dg_val[1],vtmp)
+          res[i] += dg_val[2][i]
+        else
+          dg(dg_val,u,uf.p,nothing,j)
+          res[i] += dot(dg_val,vtmp)
+        end
       end
     end
     # mean value
@@ -353,7 +364,7 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0sk
 end
 
 function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowing,t0skip,t1skip)
-  @unpack sol, S, F, window, Δt, diffcache, b, w, v, res = prob
+  @unpack sol, S, F, window, Δt, diffcache, b, w, v, dg, res = prob
   @unpack wBinv, B = S
   @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config, numparams, numindvar, uf = diffcache
 
@@ -373,14 +384,26 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowin
     for (j,u) in enumerate(sol.u)
       vtmp = @view v[(j-1)*numindvar+1:j*numindvar]
       #  final gradient result for ith parameter
-      if dg_val isa Tuple
-        DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg,pgpu_config)
-        DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg,pgpp_config)
-        res[i] += dot(dg_val[1],vtmp)*window[j]
-        res[i] += dg_val[2][i]*window[j]
+      if dg===nothing
+        if dg_val isa Tuple
+          DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg,pgpu_config)
+          DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg,pgpp_config)
+          res[i] += dot(dg_val[1],vtmp)*window[j]
+          res[i] += dg_val[2][i]*window[j]
+        else
+          DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg,pgpu_config)
+          res[i] += dot(dg_val,vtmp)*window[j]
+        end
       else
-        DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg,pgpu_config)
-        res[i] += dot(dg_val,vtmp)*window[j]
+        if dg_val isa Tuple
+          dg[1](dg_val[1],u,uf.p,nothing,j)
+          dg[2](dg_val[2],u,uf.p,nothing,j)
+          res[i] += dot(dg_val[1],vtmp)*window[j]
+          res[i] += dg_val[2][i]*window[j]
+        else
+          dg(dg_val,u,uf.p,nothing,j)
+          res[i] += dot(dg_val,vtmp)*window[j]
+        end
       end
     end
   end
@@ -388,7 +411,7 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowin
 end
 
 function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Cos2Windowing,t0skip,t1skip)
-    @unpack sol, S, F, window, Δt, diffcache, b, w, v, res = prob
+    @unpack sol, S, F, window, Δt, diffcache, b, w, v, dg, res = prob
     @unpack wBinv, B = S
     @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config, numparams, numindvar, uf = diffcache
 
@@ -408,14 +431,26 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Cos2Windowi
       for (j,u) in enumerate(sol.u)
         vtmp = @view v[(j-1)*numindvar+1:j*numindvar]
         #  final gradient result for ith parameter
-        if dg_val isa Tuple
-          DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg,pgpu_config)
-          DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg,pgpp_config)
-          res[i] += dot(dg_val[1],vtmp)*window[j]
-          res[i] += dg_val[2][i]*window[j]
+        if dg===nothing
+          if dg_val isa Tuple
+            DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg,pgpu_config)
+            DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg,pgpp_config)
+            res[i] += dot(dg_val[1],vtmp)*window[j]
+            res[i] += dg_val[2][i]*window[j]
+          else
+            DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg,pgpu_config)
+            res[i] += dot(dg_val,vtmp)*window[j]
+          end
         else
-          DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg,pgpu_config)
-          res[i] += dot(dg_val,vtmp)*window[j]
+          if dg_val isa Tuple
+            dg[1](dg_val[1],u,uf.p,nothing,j)
+            dg[2](dg_val[2],u,uf.p,nothing,j)
+            res[i] += dot(dg_val[1],vtmp)*window[j]
+            res[i] += dg_val[2][i]*window[j]
+          else
+            dg(dg_val,u,uf.p,nothing,j)
+            res[i] += dot(dg_val,vtmp)*window[j]
+          end
         end
       end
     end
@@ -424,7 +459,7 @@ end
 
 
 struct AdjointLSSProblem{A,C,solType,dtType,umidType,dudtType,SType,FType,hType,bType,wType,
-    ΔtType,G0,G,resType}
+    ΔtType,G0,G,DG,resType}
   sensealg::A
   diffcache::C
   sol::solType
@@ -440,6 +475,7 @@ struct AdjointLSSProblem{A,C,solType,dtType,umidType,dudtType,SType,FType,hType,
   Nt::Int
   g0::G0
   g::G
+  dg::DG
   res::resType
 end
 
@@ -491,7 +527,7 @@ function AdjointLSSProblem(sol, sensealg::AdjointLSS, g, dg = nothing;
   B!(S,dt,umid,sense,sensealg)
   E!(S,dudt,sensealg.alpha)
   F = SchurLU(S)
-  wBcorrect!(S,sol,g,Nt,sense,sensealg)
+  wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
 
   h!(h,g0,g,umid,p,S.wEinv)
 
@@ -500,8 +536,8 @@ function AdjointLSSProblem(sol, sensealg::AdjointLSS, g, dg = nothing;
   AdjointLSSProblem{typeof(sensealg),typeof(sense),typeof(sol),typeof(dt),
     typeof(umid),typeof(dudt),
     typeof(S),typeof(F),typeof(h),typeof(b),typeof(wa),typeof(Δt),
-    typeof(g0),typeof(g),typeof(res)}(sensealg,sense,sol,dt,umid,dudt,S,F,h,b,wa,Δt,Nt,g0,g,
-    res)
+    typeof(g0),typeof(g),typeof(dg),typeof(res)}(sensealg,sense,sol,dt,umid,dudt,S,F,h,b,wa,
+    Δt,Nt,g0,g,dg,res)
 end
 
 function h!(h,g0,g,u,p,wEinv)
@@ -517,18 +553,28 @@ function h!(h,g0,g,u,p,wEinv)
   return nothing
 end
 
-function wBcorrect!(S,sol,g,Nt,sense,sensealg)
+function wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
   @unpack dg_val, pgpu, pgpu_config, numparams, numindvar, uf = sense
   @unpack wBinv = S
 
   for (i,u) in enumerate(sol.u)
     _wBinv = @view wBinv[(i-1)*numindvar+1:i*numindvar]
-    if dg_val isa Tuple
-      DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg, pgpu_config)
-      @. _wBinv = _wBinv*dg_val[1]/Nt
+    if dg === nothing
+      if dg_val isa Tuple
+        DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg, pgpu_config)
+        @. _wBinv = _wBinv*dg_val[1]/Nt
+      else
+        DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg, pgpu_config)
+        @. _wBinv = _wBinv*dg_val/Nt
+      end
     else
-      DiffEqSensitivity.gradient!(dg_val, pgpu, u, sensealg, pgpu_config)
-      @. _wBinv = _wBinv*dg_val/Nt
+      if dg_val isa Tuple
+        dg[1](dg_val[1],u,uf.p,nothing,i)
+        @. _wBinv = _wBinv*dg_val[1]/Nt
+      else
+        dg(dg_val,u,uf.p,nothing,i)
+        @. _wBinv = _wBinv*dg_val/Nt
+      end
     end
   end
   return nothing
@@ -539,7 +585,7 @@ function __solve(prob::AdjointLSSProblem; t0skip=zero(prob.Δt), t1skip=zero(pro
 end
 
 function __solve(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0skip,t1skip)
-  @unpack sol, S, F, Δt, diffcache, h, b, wa, res, g, g0, umid = prob
+  @unpack sol, S, F, Δt, diffcache, h, b, wa, res, g, g0, dg, umid = prob
   @unpack wBinv, B, E = S
   @unpack dg_val, pgpp, pgpp_config, numparams, numindvar, uf, f, f_cache, pJ, pf, paramjac_config = diffcache
 
@@ -557,7 +603,11 @@ function __solve(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0sk
 
   if dg_val isa Tuple
     for (j,u) in enumerate(eachcol(umidres))
-      DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg, pgpp_config)
+      if dg === nothing
+        DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg, pgpp_config)
+      else
+        dg[2](dg_val[2],u,uf.p,nothing,j)
+      end
       @. res += dg_val[2]
     end
     res ./= (size(umidres)[2])

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -340,11 +340,11 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0sk
         if dg_val isa Tuple
           dg[1](dg_val[1],u,uf.p,nothing,j)
           dg[2](dg_val[2],u,uf.p,nothing,j)
-          res[i] += dot(dg_val[1],vtmp)
-          res[i] += dg_val[2][i]
+          res[i] -= dot(dg_val[1],vtmp)
+          res[i] -= dg_val[2][i]
         else
           dg(dg_val,u,uf.p,nothing,j)
-          res[i] += dot(dg_val,vtmp)
+          res[i] -= dot(dg_val,vtmp)
         end
       end
     end
@@ -398,11 +398,11 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowin
         if dg_val isa Tuple
           dg[1](dg_val[1],u,uf.p,nothing,j)
           dg[2](dg_val[2],u,uf.p,nothing,j)
-          res[i] += dot(dg_val[1],vtmp)*window[j]
-          res[i] += dg_val[2][i]*window[j]
+          res[i] -= dot(dg_val[1],vtmp)*window[j]
+          res[i] -= dg_val[2][i]*window[j]
         else
           dg(dg_val,u,uf.p,nothing,j)
-          res[i] += dot(dg_val,vtmp)*window[j]
+          res[i] -= dot(dg_val,vtmp)*window[j]
         end
       end
     end
@@ -445,11 +445,11 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Cos2Windowi
           if dg_val isa Tuple
             dg[1](dg_val[1],u,uf.p,nothing,j)
             dg[2](dg_val[2],u,uf.p,nothing,j)
-            res[i] += dot(dg_val[1],vtmp)*window[j]
-            res[i] += dg_val[2][i]*window[j]
+            res[i] -= dot(dg_val[1],vtmp)*window[j]
+            res[i] -= dg_val[2][i]*window[j]
           else
             dg(dg_val,u,uf.p,nothing,j)
-            res[i] += dot(dg_val,vtmp)*window[j]
+            res[i] -= dot(dg_val,vtmp)*window[j]
           end
         end
       end
@@ -570,10 +570,10 @@ function wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
     else
       if dg_val isa Tuple
         dg[1](dg_val[1],u,uf.p,nothing,i)
-        @. _wBinv = _wBinv*dg_val[1]/Nt
+        @. _wBinv = -_wBinv*dg_val[1]/Nt
       else
         dg(dg_val,u,uf.p,nothing,i)
-        @. _wBinv = _wBinv*dg_val/Nt
+        @. _wBinv = -_wBinv*dg_val/Nt
       end
     end
   end
@@ -605,10 +605,11 @@ function __solve(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0sk
     for (j,u) in enumerate(eachcol(umidres))
       if dg === nothing
         DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg, pgpp_config)
+        @. res += dg_val[2]
       else
         dg[2](dg_val[2],u,uf.p,nothing,j)
+        @. res -= dg_val[2]
       end
-      @. res += dg_val[2]
     end
     res ./= (size(umidres)[2])
   end

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -324,7 +324,7 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0sk
     ηres = @view η[n0:n1-1]
 
     for (j,u) in enumerate(ures)
-      vtmp = @view v[(n0+j-2)*numindvar+1:j*numindvar]
+      vtmp = @view v[(n0+j-2)*numindvar+1:(n0+j-1)*numindvar]
       #  final gradient result for ith parameter
       if dg===nothing
         if dg_val isa Tuple
@@ -338,12 +338,12 @@ function __solve(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0sk
         end
       else
         if dg_val isa Tuple
-          dg[1](dg_val[1],u,uf.p,nothing,j)
-          dg[2](dg_val[2],u,uf.p,nothing,j)
+          dg[1](dg_val[1],u,uf.p,nothing,n0+j-1)
+          dg[2](dg_val[2],u,uf.p,nothing,n0+j-1)
           res[i] -= dot(dg_val[1],vtmp)
           res[i] -= dg_val[2][i]
         else
-          dg(dg_val,u,uf.p,nothing,j)
+          dg(dg_val,u,uf.p,nothing,n0+j-1)
           res[i] -= dot(dg_val,vtmp)
         end
       end
@@ -607,7 +607,7 @@ function __solve(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0sk
         DiffEqSensitivity.gradient!(dg_val[2], pgpp, uf.p, sensealg, pgpp_config)
         @. res += dg_val[2]
       else
-        dg[2](dg_val[2],u,uf.p,nothing,j)
+        dg[2](dg_val[2],u,uf.p,nothing,n0+j-1)
         @. res -= dg_val[2]
       end
     end

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -129,7 +129,11 @@ Base.@pure function ForwardLSS(;
   ForwardLSS{chunk_size,autodiff,diff_type,typeof(alpha)}(alpha)
 end
 
-struct AdjointLSS{CS,AD,FDT,aType} <: AbstractForwardSensitivityAlgorithm{CS,AD,FDT}
+"""
+Wang, Q., Hu, R., and Blonigan, P. Least squares shadowing sensitivity analysis of
+chaotic limit cycle oscillations. Journal of Computational Physics, 267, 210-224 (2014).
+"""
+struct AdjointLSS{CS,AD,FDT,aType} <: AbstractAdjointSensitivityAlgorithm{CS,AD,FDT}
   alpha::aType # alpha: weight of the time dilation term in LSS.
 end
 Base.@pure function AdjointLSS(;

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -107,6 +107,8 @@ using Zygote
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
     @test res4 ≈ dp1[1] atol=1e-10
+
+    @show res1[1] res2[1] res3[1]
   end
 
   @testset "Lorentz" begin
@@ -164,6 +166,8 @@ using Zygote
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
     @test resfw ≈ dp1[1] atol=1e-10
+
+    @show resfw
   end
 
   @testset "T0skip and T1skip" begin
@@ -207,6 +211,7 @@ using Zygote
     @test resfw ≈ resfw_a rtol=1e-10
     @test resfw ≈ resadj_a rtol=1e-10
 
+    @show resfw
 
     function G(p; sensealg=ForwardLSS(), dt=0.01, g=nothing, t0skip=0.0, t1skip=0.0)
       _prob = remake(prob_attractor,p=p)
@@ -224,6 +229,8 @@ using Zygote
     resfw_a = DiffEqSensitivity.__solve(lss_problem_a; t0skip=10.0, t1skip=5.0)
     resadj = DiffEqSensitivity.__solve(adjointlss_problem; t0skip=10.0, t1skip=5.0)
     resadj_a = DiffEqSensitivity.__solve(adjointlss_problem_a; t0skip=10.0, t1skip=5.0)
+
+    @show resfw
 
     @test_broken resfw ≈ resadj rtol=1e-10
     @test resfw ≈ resfw_a rtol=1e-10

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -38,15 +38,15 @@ using Zygote
     adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
     adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, dg)
 
-    res1 = DiffEqSensitivity.__solve(lss_problem1)
-    res1a = DiffEqSensitivity.__solve(lss_problem1a)
-    res2 = DiffEqSensitivity.__solve(lss_problem2)
-    res2a = DiffEqSensitivity.__solve(lss_problem2a)
-    res3 = DiffEqSensitivity.__solve(lss_problem3)
-    res3a = DiffEqSensitivity.__solve(lss_problem3a)
+    res1 = shadow_forward(lss_problem1)
+    res1a = shadow_forward(lss_problem1a)
+    res2 = shadow_forward(lss_problem2)
+    res2a = shadow_forward(lss_problem2a)
+    res3 = shadow_forward(lss_problem3)
+    res3a = shadow_forward(lss_problem3a)
 
-    res4 = DiffEqSensitivity.__solve(adjointlss_problem)
-    res4a = DiffEqSensitivity.__solve(adjointlss_problem_a)
+    res4 = shadow_adjoint(adjointlss_problem)
+    res4a = shadow_adjoint(adjointlss_problem_a)
 
     @test res1[1] ≈ 1 atol=5e-2
     @test res2[1] ≈ 1 atol=5e-2
@@ -70,15 +70,15 @@ using Zygote
     adjointlss_problem = AdjointLSSProblem(sol_attractor2, AdjointLSS(alpha=10.0), g)
     adjointlss_problem_a = AdjointLSSProblem(sol_attractor2, AdjointLSS(alpha=10.0), g, dg)
 
-    res1 = DiffEqSensitivity.__solve(lss_problem1)
-    res1a = DiffEqSensitivity.__solve(lss_problem1a)
-    res2 = DiffEqSensitivity.__solve(lss_problem2)
-    res2a = DiffEqSensitivity.__solve(lss_problem2a)
-    res3 = DiffEqSensitivity.__solve(lss_problem3)
-    res3a = DiffEqSensitivity.__solve(lss_problem3a)
+    res1 = shadow_forward(lss_problem1)
+    res1a = shadow_forward(lss_problem1a)
+    res2 = shadow_forward(lss_problem2)
+    res2a = shadow_forward(lss_problem2a)
+    res3 = shadow_forward(lss_problem3)
+    res3a = shadow_forward(lss_problem3a)
 
-    res4 = DiffEqSensitivity.__solve(adjointlss_problem)
-    res4a = DiffEqSensitivity.__solve(adjointlss_problem_a)
+    res4 = shadow_adjoint(adjointlss_problem)
+    res4a = shadow_adjoint(adjointlss_problem_a)
 
     @test res1[1] ≈ 1 atol=5e-2
     @test res2[1] ≈ 1 atol=5e-2
@@ -142,10 +142,10 @@ using Zygote
     adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
     adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, (dgu,dgp))
 
-    resfw = DiffEqSensitivity.__solve(lss_problem)
-    resfw_a = DiffEqSensitivity.__solve(lss_problem_a)
-    resadj = DiffEqSensitivity.__solve(adjointlss_problem)
-    resadj_a = DiffEqSensitivity.__solve(adjointlss_problem_a)
+    resfw = shadow_forward(lss_problem)
+    resfw_a = shadow_forward(lss_problem_a)
+    resadj = shadow_adjoint(adjointlss_problem)
+    resadj_a = shadow_adjoint(adjointlss_problem_a)
 
     @test resfw ≈ resadj rtol=1e-10
     @test resfw ≈ resfw_a rtol=1e-10
@@ -153,7 +153,7 @@ using Zygote
 
     sol_attractor2 = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14, saveat=0.01)
     lss_problem = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10), g)
-    resfw = DiffEqSensitivity.__solve(lss_problem)
+    resfw = shadow_forward(lss_problem)
 
     function G(p; sensealg=ForwardLSS(), dt=0.01, g=nothing)
       _prob = remake(prob_attractor,p=p)
@@ -205,14 +205,14 @@ using Zygote
     ## ForwardLSS
 
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g)
-    resfw = DiffEqSensitivity.__solve(lss_problem)
+    resfw = shadow_forward(lss_problem)
 
     res = deepcopy(resfw)
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g),p)
     @test res ≈ dp1[1] atol=1e-10
 
-    resfw = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    resfw = shadow_forward(lss_problem; t0skip=10.0, t1skip=5.0)
     resskip = deepcopy(resfw)
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g, t0skip=10.0, t1skip=5.0),p)
@@ -223,17 +223,17 @@ using Zygote
     ## ForwardLSS with dgdu and dgdp
 
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, (dgu,dgp))
-    res2 = DiffEqSensitivity.__solve(lss_problem)
+    res2 = shadow_forward(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    res2 = shadow_forward(lss_problem; t0skip=10.0, t1skip=5.0)
     @test resskip ≈ res2 atol=1e-10
 
     ## AdjointLSS
 
     lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
-    res2 = DiffEqSensitivity.__solve(lss_problem)
+    res2 = shadow_adjoint(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    res2 = shadow_adjoint(lss_problem; t0skip=10.0, t1skip=5.0)
     @test_broken resskip ≈ res2 atol=1e-10
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
@@ -245,9 +245,9 @@ using Zygote
     ## AdjointLSS with dgdu and dgd
 
     lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, (dgu,dgp))
-    res2 = DiffEqSensitivity.__solve(lss_problem)
+    res2 = shadow_adjoint(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    res2 = shadow_adjoint(lss_problem; t0skip=10.0, t1skip=5.0)
     @test_broken resskip ≈ res2 atol=1e-10
   end
 end

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -210,30 +210,31 @@ using Zygote
     res = deepcopy(resfw)
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g),p)
-    @test resfw ≈ dp1[1] atol=1e-10
+    @test res ≈ dp1[1] atol=1e-10
 
     resfw = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    resskip = deepcopy(resfw)
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g, t0skip=10.0, t1skip=5.0),p)
-    @test resfw ≈ dp1[1] atol=1e-10
+    @test resskip ≈ dp1[1] atol=1e-10
 
-    @show res resfw
+    @show res resskip
 
     ## ForwardLSS with dgdu and dgdp
 
-    lss_problem2 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, (dgu,dgp))
-    res2 = DiffEqSensitivity.__solve(lss_problem2)
+    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, (dgu,dgp))
+    res2 = DiffEqSensitivity.__solve(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = DiffEqSensitivity.__solve(lss_problem2; t0skip=10.0, t1skip=5.0)
-    @test resfw ≈ res2 atol=1e-10
+    res2 = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    @test resskip ≈ res2 atol=1e-10
 
     ## AdjointLSS
 
-    lss_problem2 = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
-    res2 = DiffEqSensitivity.__solve(lss_problem2)
+    lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
+    res2 = DiffEqSensitivity.__solve(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = DiffEqSensitivity.__solve(lss_problem2; t0skip=10.0, t1skip=5.0)
-    @test_broken resfw ≈ res2 atol=1e-10
+    res2 = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    @test_broken resskip ≈ res2 atol=1e-10
 
     dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
     @test res ≈ dp1[1] atol=1e-10
@@ -243,10 +244,10 @@ using Zygote
 
     ## AdjointLSS with dgdu and dgd
 
-    lss_problem2 = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, (dgu,dgp))
-    res2 = DiffEqSensitivity.__solve(lss_problem2)
+    lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, (dgu,dgp))
+    res2 = DiffEqSensitivity.__solve(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = DiffEqSensitivity.__solve(lss_problem_2; t0skip=10.0, t1skip=5.0)
-    @test_broken resfw ≈ res2 atol=1e-10
+    res2 = DiffEqSensitivity.__solve(lss_problem; t0skip=10.0, t1skip=5.0)
+    @test_broken resskip ≈ res2 atol=1e-10
   end
 end

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -24,17 +24,39 @@ using Test
     sol_attractor = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14)
 
     g(u,p,t) = u[end]
+    function dg(out,u,p,t,i)
+      fill!(out, zero(eltype(u)))
+      out[end] = one(eltype(u))
+    end
     lss_problem1 = ForwardLSSProblem(sol_attractor, ForwardLSS(), g)
+    lss_problem1a = ForwardLSSProblem(sol_attractor, ForwardLSS(), nothing, dg)
     lss_problem2 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), g)
+    lss_problem2a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), nothing, dg)
     lss_problem3 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g)
+    lss_problem3a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, dg) #ForwardLSS with time dilation requires knowledge of g
+
+    adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
+    adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, dg)
 
     res1 = DiffEqSensitivity.__solve(lss_problem1)
+    res1a = DiffEqSensitivity.__solve(lss_problem1a)
     res2 = DiffEqSensitivity.__solve(lss_problem2)
+    res2a = DiffEqSensitivity.__solve(lss_problem2a)
     res3 = DiffEqSensitivity.__solve(lss_problem3)
+    res3a = DiffEqSensitivity.__solve(lss_problem3a)
+
+    res4 = DiffEqSensitivity.__solve(adjointlss_problem)
+    res4a = DiffEqSensitivity.__solve(adjointlss_problem_a)
 
     @test res1[1] ≈ 1 atol=5e-2
     @test res2[1] ≈ 1 atol=5e-2
     @test res3[1] ≈ 1 atol=5e-2
+
+    @test res1 ≈ res1a atol=1e-10
+    @test res2 ≈ res2a atol=1e-10
+    @test res3 ≈ res3a atol=1e-10
+    @test res3 ≈ res4 atol=1e-10
+    @test res3 ≈ res4a atol=1e-10
   end
 
   @testset "Lorentz" begin
@@ -55,13 +77,26 @@ using Test
     sol_attractor = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14)
 
     g(u,p,t) = u[end] + sum(p)
+    function dgu(out,u,p,t,i)
+      fill!(out, zero(eltype(u)))
+      out[end] = one(eltype(u))
+    end
+    function dgp(out,u,p,t,i)
+      fill!(out, one(eltype(p)))
+    end
 
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g)
+    lss_problem_a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, (dgu,dgp))
     adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
+    adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, (dgu,dgp))
 
     resfw = DiffEqSensitivity.__solve(lss_problem)
+    resfw_a = DiffEqSensitivity.__solve(lss_problem_a)
     resadj = DiffEqSensitivity.__solve(adjointlss_problem)
+    resadj_a = DiffEqSensitivity.__solve(adjointlss_problem_a)
 
     @test resfw ≈ resadj rtol=1e-10
+    @test resfw ≈ resfw_a rtol=1e-10
+    @test resfw ≈ resadj_a rtol=1e-10
   end
 end


### PR DESCRIPTION
`_concrete_solve_adjoint` version for #420 and #422. The minus sign convention for `dg` should be consistent with that used in the other adjoints (`BacksolveAdjoint()` etc.).