### PR TITLE
Fix specializations and reduce allocations

### DIFF
--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -212,7 +212,7 @@ function split_states(du,u,t,S::TS;update=true) where TS<:ODEInterpolatingAdjoin
     dλ    = @view du[idx1]
     dgrad = @view du[idx+1:end,1:idx]
 
-  else
+  elseif typeof(du) <: AbstractMatrix
     # non-diagonal noise and noise mixing case
     dλ    = @view du[1:idx,1:idx]
     dgrad = @view du[idx+1:end,1:idx]

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -181,10 +181,19 @@ end
 @inline function get_jacvec(alg::DiffEqBase.AbstractSensitivityAlgorithm)
   alg.autojacvec isa Bool ? alg.autojacvec : true
 end
-@inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :checkpointing) ? alg.checkpointing : false
+@inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, _) = false
+@inline ischeckpointing(alg::InterpolatingAdjoint) = alg.checkpointing || !sol.dense
 @inline ischeckpointing(alg::InterpolatingAdjoint, sol) = alg.checkpointing || !sol.dense
-@inline isnoise(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :noise) ? alg.noise : false
-@inline isnoisemixing(alg::DiffEqBase.AbstractSensitivityAlgorithm, ::Vararg) = isdefined(alg, :noisemixing) ? alg.noisemixing : false
+@inline ischeckpointing(alg::BacksolveAdjoint, _) = alg.checkpointing
+
+@inline isnoise(alg::DiffEqBase.AbstractSensitivityAlgorithm) = false
+@inline isnoise(alg::InterpolatingAdjoint) = alg.noise
+@inline isnoise(alg::BacksolveAdjoint) = alg.noise
+
+@inline isnoisemixing(alg::DiffEqBase.AbstractSensitivityAlgorithm) = false
+@inline isnoisemixing(alg::InterpolatingAdjoint) = alg.noisemixing
+@inline isnoisemixing(alg::BacksolveAdjoint) = alg.noisemixing
+
 @inline compile_tape(vjp::ReverseDiffVJP{compile}) where compile = compile
 @inline compile_tape(noise::ReverseDiffNoise{compile}) where compile = compile
 @inline compile_tape(autojacvec::Bool) = false

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -181,10 +181,10 @@ end
 @inline function get_jacvec(alg::DiffEqBase.AbstractSensitivityAlgorithm)
   alg.autojacvec isa Bool ? alg.autojacvec : true
 end
-@inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, _) = false
+@inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, sol=nothing) = false
 @inline ischeckpointing(alg::InterpolatingAdjoint) = alg.checkpointing
 @inline ischeckpointing(alg::InterpolatingAdjoint, sol) = alg.checkpointing || !sol.dense
-@inline ischeckpointing(alg::BacksolveAdjoint, _) = alg.checkpointing
+@inline ischeckpointing(alg::BacksolveAdjoint, sol=nothing) = alg.checkpointing
 
 @inline isnoise(alg::DiffEqBase.AbstractSensitivityAlgorithm) = false
 @inline isnoise(alg::InterpolatingAdjoint) = alg.noise

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -182,7 +182,7 @@ end
   alg.autojacvec isa Bool ? alg.autojacvec : true
 end
 @inline ischeckpointing(alg::DiffEqBase.AbstractSensitivityAlgorithm, _) = false
-@inline ischeckpointing(alg::InterpolatingAdjoint) = alg.checkpointing || !sol.dense
+@inline ischeckpointing(alg::InterpolatingAdjoint) = alg.checkpointing
 @inline ischeckpointing(alg::InterpolatingAdjoint, sol) = alg.checkpointing || !sol.dense
 @inline ischeckpointing(alg::BacksolveAdjoint, _) = alg.checkpointing
 


### PR DESCRIPTION
I can show there's a lack of specialization even if there is no autodiff involved:

```julia
using DiffEqSensitivity, OrdinaryDiffEq, DiffEqBase
using Test

function f(du,u,p,t)
  du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]*t
  du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
end
function foop(u,p,t)
  dx = p[1]*u[1] - p[2]*u[1]*u[2]*t
  dy = -p[3]*u[2] + p[4]*u[1]*u[2]
  [dx,dy]
end

p = [1.5,1.0,3.0,1.0]; u0 = [1.0;1.0]
prob = ODEProblem(f,u0,(0.0,10.0),p)
sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)

t = 0.0:0.5:10.0
# g(t,u,i) = (1-u)^2/2, L2 away from 1
function dg(out,u,p,t,i)
  (out.=2.0.-u)
end

using Profile
#@time _,easy_res12 = adjoint_sensitivities(sol,Tsit5(),dg,t,abstol=1e-14,reltol=1e-14,sensealg=BacksolveAdjoint(autojacvec=DiffEqSensitivity.EnzymeVJP())
#)
#@profile _,easy_res12 = adjoint_sensitivities(sol,Tsit5(),dg,t,abstol=1e-14,reltol=1e-14,sensealg=InterpolatingAdjoint(autojacvec=DiffEqSensitivity.EnzymeVJP())
#)
@time _,easy_res12 = adjoint_sensitivities(sol,Tsit5(),dg,t,abstol=1e-14,reltol=1e-14,sensealg=BacksolveAdjoint(autojacvec=false)
)
@profile _,easy_res12 = adjoint_sensitivities(sol,Tsit5(),dg,t,abstol=1e-14,reltol=1e-14,sensealg=BacksolveAdjoint(autojacvec=false)
)
Profile.clear()
Juno.profiler()

adj_prob = ODEAdjointProblem(sol,BacksolveAdjoint(autojacvec=false),dg,t,nothing)
@profile solve(adj_prob,Tsit5();
      save_everystep=false,save_start=false,saveat=eltype(sol[1])[],
      tstops=sol.t)

@code_warntype solve(adj_prob,Tsit5();
      save_everystep=false,save_start=false,saveat=eltype(sol[1])[],
      tstops=sol.t)
```

Secondary test case:

```julia
using DiffEqSensitivity, OrdinaryDiffEq, Zygote
using Test, ForwardDiff

function fiip(du,u,p,t)
  du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
  du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
end
function foop(u,p,t)
  dx = p[1]*u[1] - p[2]*u[1]*u[2]
  dy = -p[3]*u[2] + p[4]*u[1]*u[2]
  [dx,dy]
end

p = [1.5,1.0,3.0,1.0]; u0 = [1.0;1.0]
prob = ODEProblem(fiip,u0,(0.0,10.0),p)
proboop = ODEProblem(foop,u0,(0.0,10.0),p)

loss = (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=InterpolatingAdjoint()))
@time du02,dp2 = Zygote.gradient(loss,u0,p);

loss = (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP(true))))
@time du02,dp2 = Zygote.gradient(loss,u0,p);

loss = (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=InterpolatingAdjoint(autojacvec=EnzymeVJP())))
@time du02,dp2 = Zygote.gradient(loss,u0,p);

using Profile
@profile Zygote.gradient(loss,u0,p);
Juno.profiler()
Profile.clear()

loss = (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=BacksolveAdjoint(autojacvec=EnzymeVJP())))
@time du02,dp2 = Zygote.gradient(loss,u0,p);

@profile Zygote.gradient(loss,u0,p);
Juno.profiler()
Profile.clear()

loss = (u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=BacksolveAdjoint(autojacvec=false)))
@time du02,dp2 = Zygote.gradient(loss,u0,p);

using Profile
@profile Zygote.gradient(loss,u0,p);
Juno.profiler()
Profile.clear()
```