### PR TITLE
Use unperturbed norm in reverse mode forwards

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -366,7 +366,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
               _saveat = saveat
             end
 
-            _sol = solve(_prob,alg,args...;saveat=sol.t,save_idxs = _save_idxs, kwargs...)
+            _sol = solve(_prob,alg,args...;saveat=unique(sol.t),save_idxs = _save_idxs, internalnorm = UNPERTURBED_NORM, kwargs...)
             _,du = extract_local_sensitivities(_sol, sensealg, Val(true))
 
             _dp = sum(eachindex(du)) do i
@@ -446,7 +446,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
               _saveat = saveat
             end
 
-            _sol = solve(_prob,alg,args...;saveat=sol.t,save_idxs = _save_idxs, kwargs...)
+            _sol = solve(_prob,alg,args...;saveat=unique(sol.t),save_idxs = _save_idxs, internalnorm = UNPERTURBED_NORM, kwargs...)
             _,du = extract_local_sensitivities(_sol, sensealg, Val(true))
 
             _du0 = sum(eachindex(du)) do i

--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -287,3 +287,19 @@ function SciMLBase.remake(prob::ODEProblem{uType,tType,isinplace,P,F,K,<:ODEForw
                                  prob.kwargs...,kwargs...)
 end
 SciMLBase.ODEFunction(f::ODEForwardSensitivityFunction; kwargs...) = f
+
+@inline UNPERTURBED_NORM(u,t) = DiffEqBase.ODE_DEFAULT_NORM(u,t)
+
+# Support adaptive with non-dual time
+@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘value,u) / length(u))
+@inline UNPERTURBED_NORM(u::ForwardDiff.Dual,::Any) = abs(value(u))
+
+# When time is dual, it shouldn't drop the duals for adaptivity
+@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual},::ForwardDiff.Dual) = sqrt(sum(DiffEqBase.UNITLESS_ABS2,u) / length(u))
+@inline UNPERTURBED_NORM(u::ForwardDiff.Dual,::ForwardDiff.Dual) = abs(u)
+
+@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual{<:Any,<:ForwardDiff.Dual}},::ForwardDiff.Dual) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘value,u) / length(u))
+@inline UNPERTURBED_NORM(u::ForwardDiff.Dual{<:Any,ForwardDiff.Dual},::ForwardDiff.Dual) = abs(value(u))
+
+@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual{<:Any,<:ForwardDiff.Dual}},::ForwardDiff.Dual{<:Any,ForwardDiff.Dual}) = sqrt(sum(DiffEqBase.UNITLESS_ABS2,u) / length(u))
+@inline UNPERTURBED_NORM(u::ForwardDiff.Dual{<:Any,ForwardDiff.Dual},::ForwardDiff.Dual{<:Any,ForwardDiff.Dual}) = abs(u)

--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -291,15 +291,15 @@ SciMLBase.ODEFunction(f::ODEForwardSensitivityFunction; kwargs...) = f
 @inline UNPERTURBED_NORM(u,t) = DiffEqBase.ODE_DEFAULT_NORM(u,t)
 
 # Support adaptive with non-dual time
-@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘value,u) / length(u))
-@inline UNPERTURBED_NORM(u::ForwardDiff.Dual,::Any) = abs(value(u))
+@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual},::Any) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘DiffEqBase.value,u) / length(u))
+@inline UNPERTURBED_NORM(u::ForwardDiff.Dual,::Any) = abs(DiffEqBase.value(u))
 
 # When time is dual, it shouldn't drop the duals for adaptivity
 @inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual},::ForwardDiff.Dual) = sqrt(sum(DiffEqBase.UNITLESS_ABS2,u) / length(u))
 @inline UNPERTURBED_NORM(u::ForwardDiff.Dual,::ForwardDiff.Dual) = abs(u)
 
-@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual{<:Any,<:ForwardDiff.Dual}},::ForwardDiff.Dual) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘value,u) / length(u))
-@inline UNPERTURBED_NORM(u::ForwardDiff.Dual{<:Any,ForwardDiff.Dual},::ForwardDiff.Dual) = abs(value(u))
+@inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual{<:Any,<:ForwardDiff.Dual}},::ForwardDiff.Dual) = sqrt(sum(DiffEqBase.UNITLESS_ABS2∘DiffEqBase.value,u) / length(u))
+@inline UNPERTURBED_NORM(u::ForwardDiff.Dual{<:Any,ForwardDiff.Dual},::ForwardDiff.Dual) = abs(DiffEqBase.value(u))
 
 @inline UNPERTURBED_NORM(u::AbstractArray{<:ForwardDiff.Dual{<:Any,<:ForwardDiff.Dual}},::ForwardDiff.Dual{<:Any,ForwardDiff.Dual}) = sqrt(sum(DiffEqBase.UNITLESS_ABS2,u) / length(u))
 @inline UNPERTURBED_NORM(u::ForwardDiff.Dual{<:Any,ForwardDiff.Dual},::ForwardDiff.Dual{<:Any,ForwardDiff.Dual}) = abs(u)

--- a/test/stiff_adjoints.jl
+++ b/test/stiff_adjoints.jl
@@ -88,7 +88,7 @@ target_data = solve(prob0,RadauIIA5(), saveat =  0:0.5:10.0);
 
 loss_function = function(p)
     prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10)
+    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0,abstol=1e-12,reltol=1e-12)
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -133,7 +133,7 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0,abstol=1e-12,reltol=1e-12)
+    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol=1e-12,reltol=1e-12)
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];

--- a/test/stiff_adjoints.jl
+++ b/test/stiff_adjoints.jl
@@ -24,7 +24,7 @@ target_data = solve(prob0,RadauIIA5(), saveat =  0:0.5:10.0);
 
 loss_function = function(p)
     prob = remake(prob0;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10)
+    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -40,7 +40,7 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, TRBDF2(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10)
+    prediction = solve(prob, TRBDF2(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -54,7 +54,7 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, Rosenbrock23(); saveat = 0.0:0.5:10.0,abstol=1e-8,reltol=1e-8)
+    prediction = solve(prob, Rosenbrock23(); saveat = 0.0:0.5:10.0,abstol=1e-8,reltol=1e-8,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -68,7 +68,7 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0,abstol=1e-8,reltol=1e-8)
+    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0,abstol=1e-8,reltol=1e-8,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -88,7 +88,7 @@ target_data = solve(prob0,RadauIIA5(), saveat =  0:0.5:10.0);
 
 loss_function = function(p)
     prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0,abstol=1e-12,reltol=1e-12)
+    prediction = solve(prob, RadauIIA5(); saveat = 0.0:0.5:10.0,abstol=1e-14,reltol=1e-14,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -105,7 +105,7 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, TRBDF2(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10)
+    prediction = solve(prob, TRBDF2(); saveat = 0.0:0.5:10.0,abstol=1e-10,reltol=1e-10,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -119,7 +119,7 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, Rosenbrock23(); saveat = 0.0:0.5:10.0,abstol=1e-8,reltol=1e-8)
+    prediction = solve(prob, Rosenbrock23(); saveat = 0.0:0.5:10.0,abstol=1e-8,reltol=1e-8,sensealg=InterpolatingAdjoint())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];
@@ -133,7 +133,21 @@ rdgrad = Zygote.gradient(loss_function,p)[1]
 
 loss_function = function(p)
     prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
-    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol=1e-12,reltol=1e-12)
+    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol=1e-10,reltol=1e-10,sensealg=InterpolatingAdjoint())
+
+    tmpdata=prediction[[1,2],:];
+    tdata=target_data[[1,2],:];
+
+    # Calculate squared error
+    return sum(abs2,tmpdata-tdata)
+end
+
+rdgrad = Zygote.gradient(loss_function,p)[1]
+@test fdgrad ≈ rdgrad rtol=1e-3
+
+loss_function = function(p)
+    prob = remake(prob0_oop;u0=convert.(eltype(p),prob0.u0),p=p)
+    prediction = solve(prob, Rodas5(); saveat = 0.0:0.5:10.0, abstol=1e-14,reltol=1e-14,sensealg=ForwardDiffSensitivity())
 
     tmpdata=prediction[[1,2],:];
     tdata=target_data[[1,2],:];


### PR DESCRIPTION
While the correctness of https://github.com/SciML/DiffEqBase.jl/pull/529 works for most users, the OrdinaryDiffEq AD events tests showed that norm is not necessarily a good idea for this forward reverse thing, and the reason is because it can slightly change the event locations. This can cause the number of steps to change in the forward pass because you can be off by 100eps(t), get a saved step, and then an event. To correct for this, probably the best thing to do is to re-solve with the same t going forward, which is somewhat required for the backpass to generally be well-defined. While this does lose some robustness guarantees, it does seem to be the only correct solution, other than filling all of the duals before the backpass, which could be a waste due to the thunking.