### PR TITLE
Fix forward event times

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -481,8 +481,8 @@ function out_and_ts(_ts, duplicate_iterator_times, sol)
       (d ∉ _ts) && push!(_ts, d)
     end
 
-    u1 = sol(_ts)[:]
-    u2 = sol(duplicate_times,continuity=:right)[:]
+    u1 = sol(_ts).u
+    u2 = sol(duplicate_times,continuity=:right).u
     saveat = vcat(_ts,  duplicate_times...)
     perm = sortperm(saveat)
     ts = saveat[perm]

--- a/test/autodiff_events.jl
+++ b/test/autodiff_events.jl
@@ -1,0 +1,62 @@
+using DiffEqSensitivity
+using OrdinaryDiffEq, Calculus, Test
+using Zygote
+
+function f(du,u,p,t)
+  du[1] = u[2]
+  du[2] = -p[1]
+end
+
+function condition(u,t,integrator) # Event when event_f(u,t) == 0
+  u[1]
+end
+
+function affect!(integrator)
+  @show integrator.t
+  println("bounced.")
+  integrator.u[2] = -integrator.p[2]*integrator.u[2]
+end
+
+cb = ContinuousCallback(condition, affect!)
+p = [9.8, 0.8]
+prob = ODEProblem(f,eltype(p).([1.0,0.0]),eltype(p).((0.0,1.0)),copy(p))
+
+function test_f(p)
+  _prob = remake(prob, p=p)
+  solve(_prob,Tsit5(),abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)[end]
+end
+findiff = Calculus.finite_difference_jacobian(test_f,p)
+findiff
+
+using ForwardDiff
+ad = ForwardDiff.jacobian(test_f,p)
+ad
+
+@test ad ≈ findiff
+
+function test_f2(p, sensealg=ForwardDiffSensitivity(), controller=nothing, alg=Tsit5())
+  _prob = remake(prob, p=p)
+  u = solve(_prob,alg,sensealg=sensealg,controller=controller,
+    abstol=1e-14,reltol=1e-14,callback=cb,save_everystep=false)
+  u[end][end]
+end
+
+@test test_f2(p) == test_f(p)[end]
+
+g1 = Zygote.gradient(θ->test_f2(θ,ForwardDiffSensitivity()), p)
+g2 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint()), p)
+g3 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), IController()), p)
+g4 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), PIController(7//50, 2//25)), p)
+@test_broken g5 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(), PIDController(1/18. , 1/9., 1/18.)), p)
+g6 = Zygote.gradient(θ->test_f2(θ,ForwardDiffSensitivity(),
+  OrdinaryDiffEq.PredictiveController(), TRBDF2()), p)
+@test_broken g7 = Zygote.gradient(θ->test_f2(θ,ReverseDiffAdjoint(),
+    OrdinaryDiffEq.PredictiveController(), TRBDF2()), p)
+
+@test g1[1] ≈ findiff[2,1:2]
+@test g2[1] ≈ findiff[2,1:2]
+@test g3[1] ≈ findiff[2,1:2]
+@test g4[1] ≈ findiff[2,1:2]
+@test_broken g5[1] ≈ findiff[2,1:2]
+@test g6[1] ≈ findiff[2,1:2]
+@test_broken g7[1] ≈ findiff[2,1:2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,7 @@ if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "Literal Adjoint" begin include("literal_adjoint.jl") end
     @time @safetestset "ForwardDiff Chunking Adjoints" begin include("forward_chunking.jl") end
     @time @safetestset "Stiff Adjoints" begin include("stiff_adjoints.jl") end
+    @time @safetestset "Autodiff Events" begin include("autodiff_events.jl") end
     @time @safetestset "Null Parameters" begin include("null_parameters.jl") end
     @time @safetestset "Forward Mode Prob Kwargs" begin include("forward_prob_kwargs.jl") end
     @time @safetestset "Callbacks with Adjoints" begin include("callbacks.jl") end


### PR DESCRIPTION
Yeah, this one is complicated. To understand it, you kind of need to understand why the other approaches failed:

https://github.com/SciML/DiffEqSensitivity.jl/pull/435
https://github.com/SciML/DiffEqSensitivity.jl/pull/434

Essentially, you need the dual numbers in the callbacks otherwise there are cases where derivatives are not bounded by error tolerance at all. Period, no change whatsoever given the definition of the errors. But this means that your time stepping in the pure forward pass is different, and every chunk is slightly different to. That is kind of an issue for chunked forward mode when it's used in reverse mode, but we proceed. 

So the first idea was to track events to pull out the event times, but it turns out the thread-safety copy behavior makes this really hard. So the most sane solution seemed to be to discard the event times by checking non-uniqueness. In reality this is only a partial solution because someone could define events with save_positions=(true,false) or (false,true), and want to use that in a cost function. In practice, defining cost functions w.r.t. times which are not defined in advance is really... ill-defined? 

So this literally only shows up if the user somehow defined a cost function which uses whatever random t's the integrator spits out (so, not some fit against data), and if they've modified the callback so that it saves at only a single extra random point at each event. The only case I can think of even remotely sane for that is somehow a loss function on a Poincure diagram, but that's ill-defined because it's chaotic, so... I'm punting on that. What will happen in this case is someone will get an error saying that `du` or `dp` is not sized correctly to match the solution. If that error shows up in a user code we can handle it (possibly by just having them try UNPERTURBED_NORM), so at least this PR is safe and will throw an appropriate error in the bad case.

That said, this does show that chunked forward mode in reverse is a little ill-defined, and so that motivates bringing back a fully non-chunked mode. The things you learn from weird user examples...