### PR TITLE
Handle additional callback case

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -133,7 +133,9 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
                               dgrad=dgrad, dy=dy)
 
         λ .= dλ
-
+        if !(sensealg isa QuadratureAdjoint)
+          grad .-= dgrad
+        end
     end
 
     times = if typeof(cb) <: DiscreteCallback

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -229,7 +229,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     else
       cb2 = cb
     end
-
+    
     du0, dp = adjoint_sensitivities(sol,alg,args...,df,ts; sensealg=sensealg,
                                     callback = cb2,
                                     kwargs_adj...)

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -259,12 +259,14 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
 
       if callback!==nothing
         _ts, _duplicate_iterator_times = separate_nonunique(t)
-        duplicate_iterator_times = _duplicate_iterator_times[1]
-        cur_time = length(duplicate_iterator_times)
-        dλ = similar(integrand.λ)
-        dλ .*= false
-        dgrad = similar(res)
-        dgrad .*= false
+        if _duplicate_iterator_times !== nothing
+          duplicate_iterator_times = _duplicate_iterator_times[1]
+          cur_time = length(duplicate_iterator_times)
+          dλ = similar(integrand.λ)
+          dλ .*= false
+          dgrad = similar(res)
+          dgrad .*= false
+        end
       end
 
       for i in length(t)-1:-1:1
@@ -305,7 +307,7 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
               else
                 dgdu(dλ,integrand.y,integrand.p,duplicate_iterator_times[cur_time],cur_time)
               end
-              dλ .= integrand.λ-dλ 
+              dλ .= integrand.λ-dλ
               vecjacobian!(dλ, integrand.y, dλ, integrand.p, t[i], fakeS; dgrad=dgrad)
               res .+= dgrad
               cur_time -= one(cur_time)

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -440,7 +440,7 @@ end
         end
         @testset "state-dependent += callback at single time point" begin
           condition(u,t,integrator) = t == 5
-          affect!(integrator) = (integrator.u .+= integrator.p[2]//8*sin.(integrator.u))
+          affect!(integrator) = (integrator.u .+= integrator.p[2]/8*sin.(integrator.u))
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.0]
           test_discrete_callback(cb,tstops,g,dg!)
@@ -496,7 +496,7 @@ end
         end
         @testset "state-dependent += callback at single time point" begin
           condition(u,t,integrator) = t == 5
-          affect!(integrator) = (integrator.u .+= integrator.p[2]//8*sin.(integrator.u))
+          affect!(integrator) = (integrator.u .+= integrator.p[2]/8*sin.(integrator.u))
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.0]
           test_discrete_callback(cb,tstops,g,dg!)

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -110,7 +110,6 @@ function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing)
   # @test dp1 ≈ adj_sol[3:6,end]
 end
 
-
 function test_continuous_wrt_discrete_callback()
   # test the continuous callbacks wrt to the equivalent discrete callback
   function f(du,u,p,t)
@@ -255,9 +254,9 @@ function test_continuous_wrt_discrete_callback()
 
   @info dstuff
   @test du01 ≈ dstuff[1:2]
-  @test_broken dp1 ≈ dstuff[3:4]
+  @test dp1 ≈ dstuff[3:4]
   @test du02 ≈ dstuff[1:2]
-  @test_broken dp2 ≈ dstuff[3:4]
+  @test dp2 ≈ dstuff[3:4]
   @test du01 ≈ du02
   @test dp1 ≈ dp2
 end
@@ -441,7 +440,7 @@ end
         end
         @testset "state-dependent += callback at single time point" begin
           condition(u,t,integrator) = t == 5
-          affect!(integrator) = (integrator.u .+= 1//8*sin.(integrator.u))
+          affect!(integrator) = (integrator.u .+= integrator.p[2]//8*sin.(integrator.u))
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.0]
           test_discrete_callback(cb,tstops,g,dg!)
@@ -497,7 +496,7 @@ end
         end
         @testset "state-dependent += callback at single time point" begin
           condition(u,t,integrator) = t == 5
-          affect!(integrator) = (integrator.u .+= 1//8*sin.(integrator.u))
+          affect!(integrator) = (integrator.u .+= integrator.p[2]//8*sin.(integrator.u))
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.0]
           test_discrete_callback(cb,tstops,g,dg!)


### PR DESCRIPTION
This fixes the broken tests for the case when the callback doesn't change the parameters but depends on it, e.g., in

`affect!(integrator) = (integrator.u .+= integrator.p[2]//8*sin.(integrator.u))`

`QuadratureAdjoint()` is a bit nasty to fix here because I think one needs the value of the adjoint \lambda before the loss function is applied on it. However, this value is not necessarily the left or right `continuity` limit of the adjoint solution. In this first attempt, I tried to subtract it manually for the additional vjp.  