### PR TITLE
start trying to precompile and reduce compile times

### DIFF
--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -14,6 +14,8 @@ import ZygoteRules, Zygote, ReverseDiff
 import ArrayInterface
 import Enzyme
 
+import OrdinaryDiffEq
+
 using Cassette, DiffRules
 using Core: CodeInfo, SlotNumber, SSAValue, ReturnNode, GotoIfNot
 
@@ -40,6 +42,8 @@ include("steadystate_adjoint.jl")
 include("sde_tools.jl")
 include("lss.jl")
 include("nilss.jl")
+
+include("precompile.jl")
 
 export extract_local_sensitivities
 

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,38 @@
+let
+  while true
+    function lotka_volterra!(du, u, p, t)
+      x, y = u
+      α, β, δ, γ = p
+      du[1] = dx = α*x - β*x*y
+      du[2] = dy = -δ*y + γ*x*y
+    end
+
+    # Initial condition
+    u0 = [1.0, 1.0]
+
+    # Simulation interval and intermediary points
+    tspan = (0.0, 10.0)
+    tsteps = 0.0:0.1:10.0
+
+    # LV equation parameter. p = [α, β, δ, γ]
+    p = [1.5, 1.0, 3.0, 1.0]
+
+    # Setup the ODE problem, then solve
+    prob = ODEProblem(lotka_volterra!, u0, tspan, p)
+    sol = solve(prob, OrdinaryDiffEq.Tsit5())
+
+    function loss(p)
+      sol = solve(prob, OrdinaryDiffEq.Tsit5(), p=p, saveat = tsteps)
+      loss = sum(abs2, sol.-1)
+    end
+
+    callback = function (p, l, pred)
+      display(l)
+      # Tell sciml_train to not halt the optimization. If return true, then
+      # optimization stops.
+      return false
+    end
+    Zygote.gradient(loss,p)
+    break
+  end
+end


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, DiffEqSensitivity, Zygote

function lotka_volterra!(du, u, p, t)
  x, y = u
  α, β, δ, γ = p
  du[1] = dx = α*x - β*x*y
  du[2] = dy = -δ*y + γ*x*y
end

# Initial condition
u0 = [1.0, 1.0]

# Simulation interval and intermediary points
tspan = (0.0, 10.0)
tsteps = 0.0:0.1:10.0

# LV equation parameter. p = [α, β, δ, γ]
p = [1.5, 1.0, 3.0, 1.0]

# Setup the ODE problem, then solve
prob = ODEProblem(lotka_volterra!, u0, tspan, p)
sol = solve(prob, Tsit5())

function loss(p)
  sol = solve(prob, Tsit5(), p=p, saveat = tsteps)
  sum(abs2, sol.-1)
end

using SnoopCompile
tinf = @snoopi_deep Zygote.gradient(loss,p)

Before Any Precompile Work:
OrdinaryDiffEq#before_precompile
DiffEqBase#before_precompile
StochasticDiffEq@6.36
RecursiveFactorization@0.2
TriangularSolve@0.1.2

InferenceTimingNode: 12.563108/55.700412 on Core.Compiler.Timings.ROOT() with 928 direct children

Current:
InferenceTimingNode: 11.626459/45.016643 on Core.Compiler.Timings.ROOT() with 925 direct children

This PR:
InferenceTimingNode: 11.704070/43.656520 on Core.Compiler.Timings.ROOT() with 927 direct children
```

Currently it's not doing all that much.