### PR TITLE
QuadratureAdjoint() for ContinuousCallback

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -178,6 +178,12 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
 
         du = first(get_tmp_cache(integrator))
         λ,grad,y,dλ,dgrad,dy = split_states(du,integrator.u,integrator.t,S)
+        # if save_positions[2] = false, then the right limit is not saved. Thus, for 
+        # the QuadratureAdjoint we would need to lift y from the left to the right limit.
+        # However, one also needs to update dgrad later on.
+        if sensealg isa QuadratureAdjoint && !cb.save_positions[2]
+          w(y,y,integrator.p,integrator.t)
+        end 
 
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
           # correction of the loss function sensitivity for continuous callbacks

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -181,7 +181,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         # if save_positions[2] = false, then the right limit is not saved. Thus, for 
         # the QuadratureAdjoint we would need to lift y from the left to the right limit.
         # However, one also needs to update dgrad later on.
-        if sensealg isa QuadratureAdjoint && !cb.save_positions[2]
+        if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) || (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
           w(y,y,integrator.p,integrator.t)
         end 
 

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -130,7 +130,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
       ts = _prob.tspan[2]:convert(typeof(_prob.tspan[2]),abs(saveat)):_prob.tspan[1]
     end
     # if _prob.tspan[2]-_prob.tspan[1] is not a multiple of saveat, one looses the last ts value
-    sol.t[end] !== ts[end] && error("Endpoints do not match. Likely your time range is not a multiple of `saveat`. End times: ", sol.t[end], " ", ts[end])
+    sol.t[end] !== ts[end] && @warn "Endpoints do not match. Return code: $(sol.retcode). Likely your time range is not a multiple of `saveat`. sol.t[end]: $(sol.t[end]), ts[end]: $(ts[end])"
     if cb === nothing
       _out = sol(ts)
     else

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -129,6 +129,8 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     else
       ts = _prob.tspan[2]:convert(typeof(_prob.tspan[2]),abs(saveat)):_prob.tspan[1]
     end
+    # if _prob.tspan[2]-_prob.tspan[1] is not a multiple of saveat, one looses the last ts value
+    sol.t[end] !== ts[end] && error("Endpoints do not match. Likely your time range is not a multiple of `saveat`.")
     if cb === nothing
       _out = sol(ts)
     else

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -130,7 +130,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
       ts = _prob.tspan[2]:convert(typeof(_prob.tspan[2]),abs(saveat)):_prob.tspan[1]
     end
     # if _prob.tspan[2]-_prob.tspan[1] is not a multiple of saveat, one looses the last ts value
-    sol.t[end] !== ts[end] && error("Endpoints do not match. Likely your time range is not a multiple of `saveat`.")
+    sol.t[end] !== ts[end] && error("Endpoints do not match. Likely your time range is not a multiple of `saveat`. End times: ", sol.t[end], " ", ts[end])
     if cb === nothing
       _out = sol(ts)
     else

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -332,13 +332,14 @@ function test_continuous_callback(cb, g, dg!;only_backsolve=false)
   @test dp1c ≈ dstuff[3:4]
   if !only_backsolve
     @test_broken du01 ≈ du02
-    @test_broken du01 ≈ du03 rtol=1e-7
-    @test_broken du01 ≈ du03c rtol=1e-7
-    #@test_broken du03 ≈ du03c # passes sometimes, needs to be fixed with InterpolatingAdjoint
+    @test du01 ≈ du03 rtol=1e-7
+    @test du01 ≈ du03c rtol=1e-7
+    @test du03 ≈ du03c 
     @test du01 ≈ du04
     @test_broken dp1 ≈ dp2
-    @test_broken dp1 ≈ dp3
-    @test_broken dp1 ≈ dp3c
+    @test dp1 ≈ dp3
+    @test dp1 ≈ dp3c
+    @test dp3 ≈ dp3c 
     @test dp1 ≈ dp4 rtol=1e-7
 
     @test_broken du02 ≈ dstuff[1:2]

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -262,7 +262,7 @@ function test_continuous_wrt_discrete_callback()
 end
 
 
-function test_continuous_callback(cb, g, dg!)
+function test_continuous_callback(cb, g, dg!;only_backsolve=false)
   function fiip(du,u,p,t)
     du[1] = u[2]
     du[2] = -p[1]
@@ -274,7 +274,7 @@ function test_continuous_callback(cb, g, dg!)
   end
     
   u0 = [5.0,0.0]
-  tspan = (0.0,2.4)
+  tspan = (0.0,2.5)
   p = [9.8, 0.8]
 
   prob = ODEProblem(fiip,u0,tspan,p)
@@ -301,22 +301,23 @@ function test_continuous_callback(cb, g, dg!)
     (u0,p)->g(solve(proboop,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=BacksolveAdjoint(checkpointing=false))),
     u0,p)
 
-  @test_broken du02,dp2 = @time Zygote.gradient(
-    (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=ReverseDiffAdjoint()))
-    ,u0,p)
+  if !only_backsolve
+    @test_broken du02,dp2 = @time Zygote.gradient(
+     (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=ReverseDiffAdjoint()))
+     ,u0,p)
 
-  du03,dp3 = @time Zygote.gradient(
-    (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=InterpolatingAdjoint(checkpointing=true))),
-    u0,p)
+    du03,dp3 = @time Zygote.gradient(
+      (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=InterpolatingAdjoint(checkpointing=true))),
+      u0,p)
 
-  du03c,dp3c = Zygote.gradient(
-    (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=InterpolatingAdjoint(checkpointing=false))),
-    u0,p)
+    du03c,dp3c = Zygote.gradient(
+      (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=InterpolatingAdjoint(checkpointing=false))),
+      u0,p)
 
-  du04,dp4 = @time Zygote.gradient(
-    (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=QuadratureAdjoint())),
-    u0,p)
-
+    du04,dp4 = @time Zygote.gradient(
+      (u0,p)->g(solve(prob,Tsit5(),u0=u0,p=p,callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes,sensealg=QuadratureAdjoint())),
+      u0,p)
+  end
   dstuff = @time ForwardDiff.gradient(
     (θ)->g(solve(prob,Tsit5(),u0=θ[1:2],p=θ[3:4],callback=cb,abstol=abstol,reltol=reltol,saveat=savingtimes)),
     [u0;p])
@@ -329,18 +330,20 @@ function test_continuous_callback(cb, g, dg!)
   @test dp1b ≈ dstuff[3:4]
   @test du01c ≈ dstuff[1:2]
   @test dp1c ≈ dstuff[3:4]
-  @test_broken du01 ≈ du02
-  @test_broken du01 ≈ du03 rtol=1e-7
-  @test_broken du01 ≈ du03c rtol=1e-7
-  #@test_broken du03 ≈ du03c # passes sometimes, needs to be fixed with InterpolatingAdjoint
-  @test_broken du01 ≈ du04
-  @test_broken dp1 ≈ dp2
-  @test_broken dp1 ≈ dp3
-  @test_broken dp1 ≈ dp3c
-  @test_broken dp1 ≈ dp4 rtol=1e-7
+  if !only_backsolve
+    @test_broken du01 ≈ du02
+    @test_broken du01 ≈ du03 rtol=1e-7
+    @test_broken du01 ≈ du03c rtol=1e-7
+    #@test_broken du03 ≈ du03c # passes sometimes, needs to be fixed with InterpolatingAdjoint
+    @test du01 ≈ du04
+    @test_broken dp1 ≈ dp2
+    @test_broken dp1 ≈ dp3
+    @test_broken dp1 ≈ dp3c
+    @test dp1 ≈ dp4 rtol=1e-7
 
-  @test_broken du02 ≈ dstuff[1:2]
-  @test_broken dp2 ≈ dstuff[3:4]
+    @test_broken du02 ≈ dstuff[1:2]
+    @test_broken dp2 ≈ dstuff[3:4]
+  end
 
   cb2 = DiffEqSensitivity.track_callbacks(CallbackSet(cb),prob.tspan[1],prob.u0,prob.p,BacksolveAdjoint())
   sol_track = solve(prob,Tsit5(),u0=u0,p=p,callback=cb2,abstol=abstol,reltol=reltol,saveat=savingtimes)
@@ -564,7 +567,7 @@ end
         condition(u,t,integrator) = u[1]
         affect!(integrator) = (integrator.u[2] = -integrator.p[2]*integrator.u[2])
         cb = ContinuousCallback(condition,affect!,save_positions=(false,false))
-        test_continuous_callback(cb,g,dg!)
+        test_continuous_callback(cb,g,dg!;only_backsolve=true)
       end
       @testset "= callback with non-linear affect" begin
         condition(u,t,integrator) = u[1]
@@ -576,7 +579,7 @@ end
         condition(u,t,integrator) = u[1]
         affect!(integrator) = (integrator.u[2] = -integrator.p[2]*integrator.u[2]; terminate!(integrator))
         cb = ContinuousCallback(condition,affect!,save_positions=(true,true))
-        test_continuous_callback(cb,g,dg!)
+        test_continuous_callback(cb,g,dg!;only_backsolve=true)
       end
     end
     @testset "MSE loss function bouncing-ball like" begin
@@ -598,7 +601,7 @@ end
           terminate!(integrator)
         end
         cb = ContinuousCallback(condition,affect!,save_positions=(true,true))
-        test_continuous_callback(cb,g,dg!)
+        test_continuous_callback(cb,g,dg!;only_backsolve=true)
       end
     end
     @testset "MSE loss function free particle" begin


### PR DESCRIPTION
There are at least two options in `QuadratureAdjoint()` which are more difficult to support than in `BacksolveAdjoint()` 

- when one doesn't save the event time, the loop for the parameter gradients https://github.com/SciML/DiffEqSensitivity.jl/blob/b2d33c3e62fd8571e0d0028360f8534352c2af59/src/quadrature_adjoint.jl#L268 misses the necessary update. So we would need to run a check if there was an additional saved point in the adjoint which is not in `t`, push that into `t`, and check in the loop for those values. 
- terminating via `terminate!(integrator)` would also need some fixes because for `QuadratureAdjoint()` https://github.com/SciML/DiffEqSensitivity.jl/blob/b2d33c3e62fd8571e0d0028360f8534352c2af59/src/concrete_solve.jl#L128 provides a wrong time range if the full simulation time interval is not a multiple of `saveat`. (same for `InterpolatingAdjoint()`)

related issue: #374 