### PR TITLE
More tests for Neural ODEs with callbacks for different sensitivity algorithms

### DIFF
--- a/test/downstream/HybridNODE.jl
+++ b/test/downstream/HybridNODE.jl
@@ -1,4 +1,4 @@
-using DiffEqSensitivity, DifferentialEquations, DiffEqFlux, Flux
+using DiffEqSensitivity, OrdinaryDiffEq, DiffEqCallbacks, DiffEqFlux, Flux
 using Random, Test
 
 function test_hybridNODE(sensealg)

--- a/test/downstream/HybridNODE.jl
+++ b/test/downstream/HybridNODE.jl
@@ -1,0 +1,54 @@
+using DiffEqSensitivity, DifferentialEquations, DiffEqFlux, Flux
+using Random, Test
+
+function test_hybridNODE(sensealg)
+    Random.seed!(12345)
+    datalength = 100
+    tspan = (0.0,100.0)
+    t = range(tspan[1],tspan[2],length=datalength)
+    target = 3.0*(1:datalength)./datalength  # some dummy data to fit to
+    cbinput = rand(1, datalength) #some external ODE contribution
+    pmodel = Chain(
+        Dense(2, 10, initW=zeros),
+        Dense(10, 2, initW=zeros))
+    p, re = Flux.destructure(pmodel)
+    dudt(u,p,t) = re(p)(u)
+
+    # callback changes the first component of the solution every time
+    # t is an integer
+    function affect!(integrator, cbinput)
+        event_index = round(Int,integrator.t)
+        integrator.u[1] += 0.2*cbinput[event_index]
+    end
+    callback = PresetTimeCallback(collect(1:datalength),(int)->affect!(int, cbinput))
+
+    # ODE with Callback
+    prob = ODEProblem(dudt,[0.0, 1.0],tspan,p)
+
+    function predict_n_ode(p)
+        arr = Array(solve(prob, Tsit5(),
+            p=p, sensealg=sensealg, saveat=2.0, callback=callback))[1,2:2:end]
+        return arr[1:datalength]
+    end
+
+    function loss_n_ode()
+        pred = predict_n_ode(p)
+        loss = sum(abs2,target .- pred)./datalength
+    end
+
+    cb = function () #callback function to observe training
+        pred = predict_n_ode(p)
+        display(loss_n_ode())
+    end
+    @show sensealg
+    Flux.train!(loss_n_ode, Flux.params(p), Iterators.repeated((), 20), ADAM(0.005), cb = cb)
+    @test loss_n_ode() < 0.4
+    println("  ")
+end
+
+@testset "PresetTimeCallback" begin
+    test_hybridNODE(ForwardDiffSensitivity())
+    test_hybridNODE(BacksolveAdjoint())
+    test_hybridNODE(InterpolatingAdjoint())
+    test_hybridNODE(QuadratureAdjoint())
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,6 +68,7 @@ if GROUP == "DiffEqFlux"
     @time @safetestset "ForwardDiff Sparsity Components" begin include("downstream/forwarddiffsensitivity_sparsity_components.jl") end
     @time @safetestset "SDE - Neural" begin include("downstream/sde_neural.jl") end
     @time @safetestset "Complex No u" begin include("downstream/complex_no_u.jl") end
+    @time @safetestset "HybridNODE" begin include("downstream/HybridNODE.jl") end
 end
 
 if GROUP == "Callbacks"


### PR DESCRIPTION
This PR adds a test for `BacksolveAdjoint`, `InterpolatingAdjoint` and `QuadratureAdjoint` from https://github.com/SciML/DiffEqSensitivity.jl/issues/197 

Loss output for all algorithms:
```julia
13.929286083714693
11.849176349830037
9.946054506950405
8.221470597258575
6.675859697280678
5.308361230539284
4.116633668709657
3.0966739306017637
2.242654788367606
1.5467979034558708
0.9993040573034259
0.5883646361848607
0.30027807239489784
0.11969027365741683
0.029968076083835476
0.013699527219842533
0.053296103886046005
0.13165329839494805
0.23281191530403883
0.34255707381692163
```