### PR TITLE
Mutating non-diagonal noise SDE and `ForwardDiffSensitivity()`

### DIFF
--- a/src/adjoint_common.jl
+++ b/src/adjoint_common.jl
@@ -253,6 +253,7 @@ function adjointdiffcache(g::G,sensealg,discrete,sol,dg::DG,f;quad=false,noisete
             else
               ReverseDiff.GradientTape((y, _p, [tspan[2]])) do u,p,t
                 du1 = similar(p, size(prob.noise_rate_prototype))
+                du1 .= false
                 f(du1,u,p,first(t))
                 return du1[:,indx]
               end

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -378,6 +378,10 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
             end
             _prob = remake(prob,f=_f,u0=u0dual,p=pdual,tspan=tspandual)
 
+            if _prob isa SDEProblem
+              _prob.noise_rate_prototype!==nothing && (_prob = remake(_prob, noise_rate_prototype = convert.(eltype(pdual), _prob.noise_rate_prototype)))
+            end
+
             if saveat isa Number
               _saveat = prob.tspan[1]:saveat:prob.tspan[2]
             else
@@ -456,6 +460,10 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
               _f = prob.f
             end
             _prob = remake(prob,f=_f,u0=u0dual,p=pdual,tspan=tspandual)
+
+            if _prob isa SDEProblem
+              _prob.noise_rate_prototype!==nothing && (_prob = remake(_prob, noise_rate_prototype = convert.(eltype(pdual), _prob.noise_rate_prototype)))
+            end
 
             if saveat isa Number
               _saveat = prob.tspan[1]:saveat:prob.tspan[2]

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -712,7 +712,12 @@ function _jacNoise!(λ, y, p, t, S::TS, isnoise::ZygoteNoise, dgrad, dλ, dy) wh
         end
         tmp1,tmp2 = back(λ)
         dgrad[:,i] .= vec(tmp2)
-        dλ !== nothing && (dλ[:,i] .= vec(tmp1))
+        if tmp1 === nothing
+          # if a column of the noise matrix is zero, Zygote returns nothing.
+          dλ !== nothing && (dλ[:,i] .= false)
+        else
+          dλ !== nothing && (dλ[:,i] .= vec(tmp1))
+        end
         dy !== nothing && (dy[:,i] .= vec(_dy))
       end
     end

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -526,3 +526,63 @@ end
 
   @test adj_soloop[end] ≈  adj_sol[end]  rtol=1e-8
 end
+
+@testset "mutating non-diagonal noise" begin
+  a!(du,u,_p,t) = (du .= -u) 
+  a(u,_p,t) = -u 
+
+  function b!(du,u,_p,t)
+    KR, KI = _p[1:2]
+
+    du[1,1] = KR
+    du[2,1] = KI  
+  end
+
+  function b(u,_p,t)
+    KR, KI = _p[1:2]
+
+    [ KR zero(KR)
+      KI zero(KR) ]
+  end
+
+  p = [1.,0.]
+
+  prob! = SDEProblem{true}(a!,b!,[0.,0.],(0.0,0.1),p,noise_rate_prototype=eltype(p).(zeros(2,2)))
+  prob = SDEProblem{false}(a,b,[0.,0.],(0.0,0.1),p,noise_rate_prototype=eltype(p).(zeros(2,2)))
+
+  function loss(p;SDEprob=prob,sensealg=BacksolveAdjoint())
+    _prob = remake(SDEprob,p=p)
+    sol = solve(_prob, EulerHeun(), dt=1e-5, sensealg=sensealg)
+    return sum(Array(sol))
+  end
+
+  function compute_dp(p, SDEprob, sensealg)
+    Random.seed!(seed)
+    Zygote.gradient(p->loss(p,SDEprob=SDEprob,sensealg=sensealg), p)[1]
+  end
+
+  # test mutating against non-mutating
+
+  # non-mutating
+  
+  dp1 = compute_dp(p, prob, ForwardDiffSensitivity())
+  dp2 = compute_dp(p, prob, BacksolveAdjoint())
+  dp3 = compute_dp(p, prob, InterpolatingAdjoint())
+
+  @show dp1 dp2 dp3
+
+  # different vjp choice
+  _dp2 = compute_dp(p, prob, BacksolveAdjoint(autojacvec=ReverseDiffVJP()))
+  @test dp2 ≈ _dp2 rtol=1e-8
+  _dp3 = compute_dp(p, prob, InterpolatingAdjoint(autojacvec=ReverseDiffVJP()))
+  @test dp3 ≈ _dp3 rtol=1e-8
+
+  # mutating 
+  _dp1 = compute_dp(p, prob!, ForwardDiffSensitivity())
+  _dp2 = @test_broken compute_dp(p, prob!, BacksolveAdjoint())
+  _dp3 = @test_broken compute_dp(p, prob!, InterpolatingAdjoint())
+
+  @test dp1 ≈ _dp1 rtol=1e-8
+  @test_broken dp2 ≈ _dp2 rtol=1e-8
+  @test_broken dp3 ≈ _dp3 rtol=1e-8
+end

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -579,10 +579,10 @@ end
 
   # mutating 
   _dp1 = compute_dp(p, prob!, ForwardDiffSensitivity())
-  _dp2 = @test_broken compute_dp(p, prob!, BacksolveAdjoint())
-  _dp3 = @test_broken compute_dp(p, prob!, InterpolatingAdjoint())
+  _dp2 = compute_dp(p, prob!, BacksolveAdjoint())
+  _dp3 = compute_dp(p, prob!, InterpolatingAdjoint())
 
   @test dp1 ≈ _dp1 rtol=1e-8
-  @test_broken dp2 ≈ _dp2 rtol=1e-8
-  @test_broken dp3 ≈ _dp3 rtol=1e-8
+  @test dp2 ≈ _dp2 rtol=1e-8
+  @test dp3 ≈ _dp3 rtol=1e-8
 end


### PR DESCRIPTION
Fixes https://github.com/SciML/DiffEqSensitivity.jl/issues/487.
`gtmp` in the SDE solver was not of Dual type. So, `noise_rate_prototype` needed to be converted as well. 

Zygote returns `nothing` for the vjp for the second column of the noise matrix in the example. So I added a check for such cases in `_jacNoise!`. 

The mutation breaks something for ReverseDiff, which I didn't solve yet. While the non-mutating version:
```julia
function b(u,_p,t)
    KR, KI = _p[1:2]

    [ KR zero(KR)
      KI zero(KR) ]
end

DiffEqSensitivity.ReverseDiff.GradientTape((randn(2), randn(2), [1.0])) do u,p,t
    du1 = b(u,p,first(t))
    return du1[:,2]
end
```
works fine. The mutating one
```julia
function b!(du,u,_p,t)
    KR, KI = _p[1:2]

    du[1,1] = KR
    du[2,1] = KI
end

DiffEqSensitivity.ReverseDiff.GradientTape((randn(2), randn(2), [1.0])) do u,p,t
    du1 = similar(p, size(zeros(2,2)))
    b!(du1,u,p,first(t))
    return du1[:,2]
end
```
 throws an error (for the second column; the first one, `du1[:,1]`, seems to work)
```
ERROR: LoadError: UndefRefError: access to undefined reference
Stacktrace:
  [1] getindex
    @ ./array.jl:802 [inlined]
  [2] macro expansion
    @ ./multidimensional.jl:860 [inlined]
  [3] macro expansion
    @ ./cartesian.jl:64 [inlined]
  [4] _unsafe_getindex!
    @ ./multidimensional.jl:855 [inlined]
  [5] _unsafe_getindex(::IndexLinear, ::Matrix{ReverseDiff.TrackedReal{Float64, Float64, ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}}}, ::Base.Slice{Base.OneTo{Int64}}, ::Int64)
    @ Base ./multidimensional.jl:846
  [6] _getindex
    @ ./multidimensional.jl:832 [inlined]
  [7] getindex
    @ ./abstractarray.jl:1170 [inlined]
  [8] macro expansion
    @ ./show.jl:955 [inlined]
  [9] (::var"#99#100")(u::ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}, p::ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}, t::ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}})
    @ Main ~/ownCloud/Private/JSoC2021/OtherIssues/non_diagonal_noise_SDEs/issue487.jl:70
 [10] ReverseDiff.GradientTape(f::Function, input::Tuple{Vector{Float64}, Vector{Float64}, Vector{Float64}}, cfg::ReverseDiff.GradientConfig{Tuple{ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}, ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}, ReverseDiff.TrackedArray{Float64, Float64, 1, Vector{Float64}, Vector{Float64}}}})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/E4Tzn/src/api/tape.jl:207
 [11] ReverseDiff.GradientTape(f::Function, input::Tuple{Vector{Float64}, Vector{Float64}, Vector{Float64}})
    @ ReverseDiff ~/.julia/packages/ReverseDiff/E4Tzn/src/api/tape.jl:204
 [12] top-level scope
    @ ~/ownCloud/Private/JSoC2021/OtherIssues/non_diagonal_noise_SDEs/issue487.jl:64
```
