### PR TITLE
Fix: swap u and p in TrackedAffect

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -61,7 +61,7 @@ struct TrackedAffect{T,T2,T3,T4,T5}
 end
 
 TrackedAffect(t::Number,u,p,affect!::Nothing,correction) = nothing
-TrackedAffect(t::Number,u,p,affect!,correction) = TrackedAffect(Vector{typeof(t)}(undef,0),Vector{typeof(p)}(undef,0),Vector{typeof(u)}(undef,0),affect!,correction)
+TrackedAffect(t::Number,u,p,affect!,correction) = TrackedAffect(Vector{typeof(t)}(undef,0),Vector{typeof(u)}(undef,0),Vector{typeof(p)}(undef,0),affect!,correction)
 
 function (f::TrackedAffect)(integrator)
     uleft = deepcopy(integrator.u)

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -32,7 +32,7 @@ function ImplicitCorrection(cb,t,u,p,sensealg)
   gt_val = similar(u,1)
   gu_val = similar(u)
 
-  fakeinteg = FakeIntegrator(u,p,t)
+  fakeinteg = FakeIntegrator(u,p,t,t)
   gt = ConditionTimeWrapper(condition,u,fakeinteg)
   gu = ConditionUWrapper(condition,t,fakeinteg)
 
@@ -120,13 +120,12 @@ function _track_callback(cb::VectorContinuousCallback,t,u,p,sensealg)
                cb.dtrelax,cb.abstol,cb.reltol,cb.repeat_nudge)
 end
 
-struct FakeIntegrator{uType,P,tType}
+struct FakeIntegrator{uType,P,tType,tprevType}
     u::uType
     p::P
     t::tType
-    tprev::tType
+    tprev::tprevType
 end
-FakeIntegrator(u,p,t,tprev) = FakeIntegrator{eltype(u),eltype(p),eltype(t)}(u,p,t,tprev)
 
 struct CallbackSensitivityFunction{fType,Alg<:DiffEqBase.AbstractSensitivityAlgorithm,C<:AdjointDiffCache,pType} <: SensitivityFunction
     f::fType
@@ -302,7 +301,7 @@ function get_indx(cb::Union{ContinuousCallback,VectorContinuousCallback}, t)
 end
 
 get_tprev(cb::DiscreteCallback,indx,bool) = cb.affect!.tprev[indx]
-function copy_to_integrator!(cb::Union{ContinuousCallback,VectorContinuousCallback}, indx, bool)
+function get_tprev(cb::Union{ContinuousCallback,VectorContinuousCallback}, indx, bool)
   if bool
     return cb.affect!.tprev[indx]
   else

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -54,6 +54,7 @@ end
 
 struct TrackedAffect{T,T2,T3,T4,T5}
     event_times::Vector{T}
+    tprev::Vector{T}
     uleft::Vector{T2}
     pleft::Vector{T3}
     affect!::T4
@@ -61,7 +62,7 @@ struct TrackedAffect{T,T2,T3,T4,T5}
 end
 
 TrackedAffect(t::Number,u,p,affect!::Nothing,correction) = nothing
-TrackedAffect(t::Number,u,p,affect!,correction) = TrackedAffect(Vector{typeof(t)}(undef,0),Vector{typeof(u)}(undef,0),Vector{typeof(p)}(undef,0),affect!,correction)
+TrackedAffect(t::Number,u,p,affect!,correction) = TrackedAffect(Vector{typeof(t)}(undef,0),Vector{typeof(t)}(undef,0),Vector{typeof(u)}(undef,0),Vector{typeof(p)}(undef,0),affect!,correction)
 
 function (f::TrackedAffect)(integrator)
     uleft = deepcopy(integrator.u)
@@ -70,11 +71,13 @@ function (f::TrackedAffect)(integrator)
     if integrator.u_modified
         if isempty(f.event_times)
           push!(f.event_times,integrator.t)
+          push!(f.tprev,integrator.tprev)
           push!(f.uleft,uleft)
           push!(f.pleft,pleft)
         else
           if !maximum(.≈(integrator.t, f.event_times, rtol=0.0, atol=1e-14))
             push!(f.event_times,integrator.t)
+            push!(f.tprev,integrator.tprev)
             push!(f.uleft,uleft)
             push!(f.pleft,pleft)
           end
@@ -121,7 +124,9 @@ struct FakeIntegrator{uType,P,tType}
     u::uType
     p::P
     t::tType
+    tprev::tType
 end
+FakeIntegrator(u,p,t,tprev=t) = FakeIntegrator(u,p,t,tprev)
 
 struct CallbackSensitivityFunction{fType,Alg<:DiffEqBase.AbstractSensitivityAlgorithm,C<:AdjointDiffCache,pType} <: SensitivityFunction
     f::fType
@@ -165,8 +170,11 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
 
     function affect!(integrator)
 
-        function w(du,u,p,t)
-          fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t)
+        indx, pos_neg = get_indx(cb, integrator.t)
+        tprev = get_tprev(cb,indx,pos_neg)
+
+        function w(du,u,p,t,tprev)
+          fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
           _affect! = get_affect!(cb.affect!.affect!)
           _affect!(fakeinteg)
           du .= fakeinteg.u
@@ -175,7 +183,8 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         S = integrator.f.f # get the sensitivity function
 
         # Create a fake sensitivity function to do the vjps
-        fakeS = CallbackSensitivityFunction(w,sensealg,S.diffcache,integrator.sol.prob)
+        fakeS = CallbackSensitivityFunction((du,u,p,t)->w(du,u,p,t,tprev),sensealg,
+                        S.diffcache,integrator.sol.prob)
 
         du = first(get_tmp_cache(integrator))
         λ,grad,y,dλ,dgrad,dy = split_states(du,integrator.u,integrator.t,S)
@@ -183,7 +192,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         # the QuadratureAdjoint we would need to lift y from the left to the right limit.
         # However, one also needs to update dgrad later on.
         if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) || (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
-          w(y,y,integrator.p,integrator.t)
+          w(y,y,integrator.p,integrator.t,tprev)
         end 
 
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
@@ -197,20 +206,20 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
           compute_f!(dy_right,S,y,integrator)
           # if callback did not terminate the time evolution, we have to compute one more correction term.
           if cb.save_positions[2] && !correction.terminated
-            indx = correction.cur_time[] + 1
-            loss_correction!(Lu_right,y,integrator,g,indx)
+            loss_indx = correction.cur_time[] + 1
+            loss_correction!(Lu_right,y,integrator,g,loss_indx)
           else
             Lu_right .*= false
           end
         end
 
-        update_p = copy_to_integrator!(cb,y,integrator.p,integrator.t)
+        update_p = copy_to_integrator!(cb,y,integrator.p,integrator.t,indx,pos_neg)
 
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
           # compute the correction of the right limit (with left state limit inserted into dgdt)
           @unpack dy_left, cur_time = correction
           compute_f!(dy_left,S,y,integrator)
-          dgdt(dy_left,correction,sensealg,y,integrator)
+          dgdt(dy_left,correction,sensealg,y,integrator,tprev)
           if !correction.terminated
             implicit_correction!(Lu_right,dλ,λ,dy_right,correction)
             correction.terminated = false # additional callbacks might have happened which didn't terminate the time evolution  
@@ -220,14 +229,15 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         if update_p
           # changes in parameters
           if !(sensealg isa QuadratureAdjoint)
-            function wp(dp,p,u,t)
-              fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t)
+            
+            function wp(dp,p,u,t,tprev)
+              fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
               _affect! = get_affect!(cb.affect!.affect!)
               _affect!(fakeinteg)
               dp .= fakeinteg.p
             end
 
-            fakeSp = CallbackSensitivityFunction(wp,sensealg,S.diffcache,integrator.sol.prob)
+            fakeSp = CallbackSensitivityFunction((du,u,p,t)->wp(du,u,p,t,tprev),sensealg,S.diffcache,integrator.sol.prob)
             #vjp with Jacobin given by dw/dp before event and vector given by grad
             vecjacobian!(dgrad, integrator.p, grad, y, integrator.t, fakeSp;
                                   dgrad=nothing, dy=nothing)
@@ -248,8 +258,8 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
 
           if cb.save_positions[1] == true
             # if the callback saved the first position, we need to implicitly correct this value as well
-            indx = correction.cur_time[] 
-            implicit_correction!(Lu_left,dy_left,correction,y,integrator,g,indx)
+            loss_indx = correction.cur_time[] 
+            implicit_correction!(Lu_left,dy_left,correction,y,integrator,g,loss_indx)
             dλ .+= Lu_left
           end
         end
@@ -273,30 +283,45 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
                        save_positions = (false,false))
 end
 
+get_indx(cb::DiscreteCallback,t) = (searchsortedfirst(cb.affect!.event_times,t), nothing)
+function get_indx(cb::Union{ContinuousCallback,VectorContinuousCallback}, t)
+  if !isempty(cb.affect!.event_times)
+    indx = searchsortedfirst(cb.affect!.event_times,t)
+    if cb.affect!.event_times[indx]!=t
+      bool = false
+      indx = searchsortedfirst(cb.affect_neg!.event_times,t)
+    else
+      bool = true
+    end
+  else
+    bool = false
+    indx = searchsortedfirst(cb.affect_neg!.event_times,t)
+  end
+  return indx, bool
+end
 
-function copy_to_integrator!(cb::DiscreteCallback, y, p, t)
-  indx = searchsortedfirst(cb.affect!.event_times,t)
+get_tprev(cb::DiscreteCallback,indx,bool) = cb.affect!.tprev[indx]
+function copy_to_integrator!(cb::Union{ContinuousCallback,VectorContinuousCallback}, indx, bool)
+  if bool
+    return cb.affect!.tprev[indx]
+  else
+    return cb.affect_neg!.tprev[indx]
+  end
+end
+
+function copy_to_integrator!(cb::DiscreteCallback, y, p, t, indx, bool)
   copyto!(y, cb.affect!.uleft[indx])
   update_p = (p != cb.affect!.pleft[indx])
   update_p && copyto!(p, cb.affect!.pleft[indx])
   update_p
 end
 
-function copy_to_integrator!(cb::Union{ContinuousCallback,VectorContinuousCallback}, y, p, t)
-  if !isempty(cb.affect!.event_times)
-    indx = searchsortedfirst(cb.affect!.event_times,t)
-    if cb.affect!.event_times[indx]!=t
-      indx = searchsortedfirst(cb.affect_neg!.event_times,t)
-      copyto!(y, cb.affect_neg!.uleft[indx])
-      update_p = (p != cb.affect!.pleft[indx])
-      update_p && copyto!(p, cb.affect_neg!.pleft[indx])
-    else
-      copyto!(y, cb.affect!.uleft[indx])
-      update_p = (p != cb.affect!.pleft[indx])
-      update_p && copyto!(p, cb.affect!.pleft[indx])
-    end
+function copy_to_integrator!(cb::Union{ContinuousCallback,VectorContinuousCallback}, y, p, t, indx, bool)
+  if bool
+    copyto!(y, cb.affect!.uleft[indx])
+    update_p = (p != cb.affect!.pleft[indx])
+    update_p && copyto!(p, cb.affect!.pleft[indx])
   else
-    indx = searchsortedfirst(cb.affect_neg!.event_times,t)
     copyto!(y, cb.affect_neg!.uleft[indx])
     update_p = (p != cb.affect_neg!.pleft[indx])
     update_p && copyto!(p, cb.affect_neg!.pleft[indx])
@@ -315,13 +340,13 @@ function compute_f!(dy,S,y,integrator)
   return nothing
 end
 
-function dgdt(dy,correction,sensealg,y,integrator)
+function dgdt(dy,correction,sensealg,y,integrator,tprev)
   # dy refers to f evaluated on left limit
   @unpack gt_val, gu_val, gt, gu, gt_conf, gu_conf, condition = correction
 
   p, t = integrator.p, integrator.t
 
-  fakeinteg = FakeIntegrator([x for x in y],p,t)
+  fakeinteg = FakeIntegrator([x for x in y],p,t,tprev)
 
   # derivative and gradient of condition with respect to time and state, respectively
   gt.u = y

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -126,7 +126,7 @@ struct FakeIntegrator{uType,P,tType}
     t::tType
     tprev::tType
 end
-FakeIntegrator(u,p,t,tprev=t) = FakeIntegrator(u,p,t,tprev)
+FakeIntegrator(u,p,t,tprev) = FakeIntegrator{eltype(u),eltype(p),eltype(t)}(u,p,t,tprev)
 
 struct CallbackSensitivityFunction{fType,Alg<:DiffEqBase.AbstractSensitivityAlgorithm,C<:AdjointDiffCache,pType} <: SensitivityFunction
     f::fType

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -193,7 +193,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         # However, one also needs to update dgrad later on.
         if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) # || (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
           # lifting for InterpolatingAdjoint is not needed anymore. Callback is already applied. 
-          w(y,y,integrator.p,integrator.t)
+          w(y,y,integrator.p,integrator.t,tprev)
         end 
 
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -209,7 +209,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
       _out = sol(ts)
     else
       _ts, duplicate_iterator_times = separate_nonunique(sol.t)
-      _out, ts = out_and_ts(_ts, duplicate_iterator_times, sol)
+      _out, ts = out_and_ts(_saveat, duplicate_iterator_times, sol)
     end
 
     out = if save_idxs === nothing

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -232,14 +232,19 @@ end
   discrete = t !== nothing
 
   # remove duplicates from checkpoints
-  if ischeckpointing(sensealg,sol) &&  (length(unique(checkpoints)) != length(checkpoints))
+  if ischeckpointing(sensealg, sol) && (length(unique(checkpoints)) != length(checkpoints))
     _checkpoints, duplicate_iterator_times = separate_nonunique(checkpoints)
     tstops = duplicate_iterator_times[1]
-    checkpoints = filter(x->x ∉ tstops, _checkpoints)
+    checkpoints = filter(x -> x ∉ tstops, _checkpoints)
     # check if start is in checkpoints. Otherwise first interval is missed.
     if checkpoints[1] != tspan[2]
-      pushfirst!(checkpoints,tspan[2])
+      pushfirst!(checkpoints, tspan[2])
     end
+  
+    if haskey(kwargs, :tstops)
+     (tstops !== kwargs[:tstops]) && unique!(push!(tstops, kwargs[:tstops]...))
+    end
+
   else
     tstops = nothing
   end

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -14,9 +14,9 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
                                    kwargs...)
 
   if sol.prob isa ODEProblem
-    adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,
+    adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg; checkpoints=checkpoints,
                                  callback = callback,
-                                 abstol=abstol,reltol=reltol)
+                                 abstol=abstol,reltol=reltol, kwargs...)
 
   elseif sol.prob isa SDEProblem
     adj_prob = SDEAdjointProblem(sol,sensealg,g,t,dg,checkpoints=checkpoints,

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -482,7 +482,7 @@ end
           condition(u,t,integrator) = t == 5
           affect!(integrator) = (@show integrator.tprev; integrator.u[1] += integrator.t-integrator.tprev)
           cb = DiscreteCallback(condition,affect!)
-          tstops=[5.0]
+          tstops = [4.999, 5.0]
           test_discrete_callback(cb,tstops,g,dg!,nothing,true)
         end
       end
@@ -544,7 +544,7 @@ end
           condition(u,t,integrator) = t == 5
           affect!(integrator) = (@show integrator.tprev; integrator.u[1] += integrator.t-integrator.tprev)
           cb = DiscreteCallback(condition,affect!)
-          tstops=[5.0]
+          tstops = [4.999, 5.0]
           test_discrete_callback(cb,tstops,g,dg!,nothing,true)
         end
       end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -5,7 +5,7 @@ abstol=1e-12
 reltol=1e-12
 savingtimes=0.5
 
-function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing)
+function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing, tprev=false)
   function fiip(du,u,p,t)
     du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
     du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
@@ -70,24 +70,36 @@ function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing)
 
   @info dstuff
 
-  @test du01 ≈ dstuff[1:2]
-  @test dp1 ≈ dstuff[3:6]
-  @test du01b ≈ dstuff[1:2]
-  @test dp1b ≈ dstuff[3:6]
-  @test du01c ≈ dstuff[1:2]
-  @test dp1c ≈ dstuff[3:6]
-  @test du01 ≈ du02
+  # tests wrt discrete sensitivities
+  if tprev
+    # tprev depends on stepping behaviour of integrator. Thus sensitivities are necessarily (slightly) different. 
+    @test du02 ≈ dstuff[1:2] rtol=1e-3
+    @test dp2 ≈ dstuff[3:6]  rtol=1e-3
+    @test du01 ≈ dstuff[1:2] rtol=1e-3
+    @test dp1 ≈ dstuff[3:6] rtol=1e-3
+    @test du01 ≈ du02 rtol=1e-3
+    @test dp1 ≈ dp2 rtol=1e-3
+  else
+    @test du02 ≈ dstuff[1:2]
+    @test dp2 ≈ dstuff[3:6]
+    @test du01 ≈ dstuff[1:2]
+    @test dp1 ≈ dstuff[3:6]
+    @test du01 ≈ du02
+    @test dp1 ≈ dp2
+  end
+
+  # tests wrt continuous sensitivities
+  @test du01b ≈ du01
+  @test dp1b ≈ dp1
+  @test du01c ≈ du01
+  @test dp1c ≈ dp1
   @test du01 ≈ du03 rtol=1e-7
   @test du01 ≈ du03c rtol=1e-7
   @test du03 ≈ du03c
   @test du01 ≈ du04
-  @test dp1 ≈ dp2
   @test dp1 ≈ dp3
   @test dp1 ≈ dp3c
   @test dp1 ≈ dp4 rtol=1e-7
-
-  @test du02 ≈ dstuff[1:2]
-  @test dp2 ≈ dstuff[3:6]
 
   cb2 = DiffEqSensitivity.track_callbacks(CallbackSet(cb),prob.tspan[1],prob.u0,prob.p,BacksolveAdjoint())
   sol_track = solve(prob,Tsit5(),u0=u0,p=p,callback=cb2,tstops=tstops,abstol=abstol,reltol=reltol,saveat=savingtimes)
@@ -471,7 +483,7 @@ end
           affect!(integrator) = (@show integrator.tprev; integrator.u[1] += integrator.t-integrator.tprev)
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.0]
-          test_discrete_callback(cb,tstops,g,dg!)
+          test_discrete_callback(cb,tstops,g,dg!,nothing,true)
         end
       end
       @testset "MSE loss function" begin
@@ -533,7 +545,7 @@ end
           affect!(integrator) = (@show integrator.tprev; integrator.u[1] += integrator.t-integrator.tprev)
           cb = DiscreteCallback(condition,affect!)
           tstops=[5.0]
-          test_discrete_callback(cb,tstops,g,dg!)
+          test_discrete_callback(cb,tstops,g,dg!,nothing,true)
         end
       end
   	end

--- a/test/callbacks.jl
+++ b/test/callbacks.jl
@@ -466,6 +466,13 @@ end
           tstops=[5.1]
           test_discrete_callback(cb,tstops,g,dg!,cboop)
         end
+        @testset "tprev dependent callback" begin
+          condition(u,t,integrator) = t == 5
+          affect!(integrator) = (@show integrator.tprev; integrator.u[1] += integrator.t-integrator.tprev)
+          cb = DiscreteCallback(condition,affect!)
+          tstops=[5.0]
+          test_discrete_callback(cb,tstops,g,dg!)
+        end
       end
       @testset "MSE loss function" begin
         g(u) = sum((1.0.-u).^2)./2
@@ -520,6 +527,13 @@ end
           cboop = DiscreteCallback(condition,affect)
           tstops=[5.1]
           test_discrete_callback(cb,tstops,g,dg!,cboop)
+        end
+        @testset "tprev dependent callback" begin
+          condition(u,t,integrator) = t == 5
+          affect!(integrator) = (@show integrator.tprev; integrator.u[1] += integrator.t-integrator.tprev)
+          cb = DiscreteCallback(condition,affect!)
+          tstops=[5.0]
+          test_discrete_callback(cb,tstops,g,dg!)
         end
       end
   	end

--- a/test/downstream/HybridNODE.jl
+++ b/test/downstream/HybridNODE.jl
@@ -116,8 +116,7 @@ end
 mutable struct Affect{T}
       callback_data::T
 end
-compute_index(t) = Int(t ÷ 1 + 1)
-Zygote.@nograd compute_index #avoid taking grads of this function
+compute_index(t) = round(Int,t)+1
 function (cb::Affect)(integrator)
     indx = compute_index(integrator.t)
     integrator.u .= integrator.u .+ @view(cb.callback_data[:, indx, 1]) * (integrator.t - integrator.tprev)

--- a/test/downstream/HybridNODE.jl
+++ b/test/downstream/HybridNODE.jl
@@ -112,6 +112,9 @@ function test_hybridNODE2(sensealg)
     println("  ")
 end
 
+mutable struct Affect{T}
+      callback_data::T
+end
 function test_hybridNODE3(sensealg)
     u0 = Float32[2.; 0.]
     datasize = 100
@@ -139,9 +142,7 @@ function test_hybridNODE3(sensealg)
     z0 = Float32[2.; 0.]
     prob = ODEProblem(dudt,z0,tspan)
     
-    mutable struct Affect{T}
-      callback_data::T
-    end
+    
     function callback_(callback_data)
         affect! = Affect(callback_data)
         condition(u,t,integrator) = integrator.t > 0 

--- a/test/downstream/HybridNODE.jl
+++ b/test/downstream/HybridNODE.jl
@@ -115,6 +115,9 @@ end
 mutable struct Affect{T}
       callback_data::T
 end
+function (cb::Affect)(integrator)
+    integrator.u .= integrator.u .+ cb.callback_data[:,Int(integrator.t÷60+1),1] * (integrator.t-integrator.tprev)
+end
 function test_hybridNODE3(sensealg)
     u0 = Float32[2.; 0.]
     datasize = 100
@@ -147,10 +150,6 @@ function test_hybridNODE3(sensealg)
         affect! = Affect(callback_data)
         condition(u,t,integrator) = integrator.t > 0 
         DiscreteCallback(condition,affect!,save_positions=(false,false))
-    end
-    
-    function (cb::Affect)(integrator)
-        integrator.u .= integrator.u .+ cb.callback_data[:,Int(integrator.t÷60+1),1] * (integrator.t-integrator.tprev)
     end
     
     function predict_n_ode(true_data_0,callback_data, sense)


### PR DESCRIPTION
The main error:
`MethodError: no method matching Vector{Float32}(::Matrix{Float32})`
in https://github.com/SciML/DiffEqSensitivity.jl/issues/503 is due to a swap between `typeof(u)` and `typeof(p)`. 

There are follow up errors like: 
`type FakeIntegrator has no field tprev`

@ChrisRackauckas Should we copy `tprev` to the fakeintegrator as well (or is there a better way to solve it)?