### PR TITLE
Try moving to `juliaecosystem`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
       - JuliaCI/julia-test#v1:
           coverage: false
     agents:
-      queue: "juliacpu"
+      queue: "juliaecosystem"
     env:
       GROUP: 'Callbacks'
     timeout_in_minutes: 120


### PR DESCRIPTION
We don't have GPU runners on the sandbox runners yet, but we may eventually get them.  Until then, we can continue to use `juliagpu`.