### PR TITLE
remove state lifting in callback tracking for InterpolatingAdjoint with checkpointing

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,7 @@ steps:
       - JuliaCI/julia-test#v1:
           coverage: false
     agents:
+      os: "linux"
       queue: "juliaecosystem"
     env:
       GROUP: 'Callbacks'

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -182,7 +182,8 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         # if save_positions[2] = false, then the right limit is not saved. Thus, for 
         # the QuadratureAdjoint we would need to lift y from the left to the right limit.
         # However, one also needs to update dgrad later on.
-        if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) || (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
+        if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) # || (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
+          # lifting for InterpolatingAdjoint is not needed anymore. Callback is already applied. 
           w(y,y,integrator.p,integrator.t)
         end 
 


### PR DESCRIPTION
It looks like the test failure seen in https://github.com/SciML/DiffEqSensitivity.jl/pull/534 and following PRs is due to the state lifting in the `affect!` function. 

So far, we had to manually lift the state to the value after the CB is applied to compute the vjp with respect to the callback application. 

For example, for the bouncing ball, 
```julia
y = [6.083766289256748e-15, -9.899494936611664] # left limit of the event
y = [6.083766289256748e-15, 7.919595949289331] # right limit of the event
```
The test errors we observed are caused by an additional (incorrect) application of the affect function to the state at the right limit. 