### PR TITLE
swap signs adjoint

### DIFF
--- a/src/backsolve_adjoint.jl
+++ b/src/backsolve_adjoint.jl
@@ -40,6 +40,7 @@ function (S::ODEBacksolveSensitivityFunction)(du,u,p,t)
     vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad, dy=dy)
   end
   dλ .*= -1
+  dgrad .*= -one(eltype(dgrad))
 
   discrete || accumulate_cost!(dλ, y, p, t, S, dgrad)
   return nothing
@@ -54,6 +55,7 @@ function (S::ODEBacksolveSensitivityFunction)(du,u,p,t,W)
 
   vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad, dy=dy,W=W)
   dλ .*= -one(eltype(λ))
+  dgrad .*= -one(eltype(dgrad))
 
   discrete || accumulate_cost!(dλ, y, p, t, S, dgrad)
   return nothing

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -278,7 +278,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         vecjacobian!(dλ, y, λ, integrator.p, integrator.t, fakeS;
                               dgrad=dgrad, dy=dy)
 
-        dgrad .*= -one(eltype(dgrad))
+        dgrad!==nothing && (dgrad .*= -1)
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
           # second correction to correct for left limit
           @unpack Lu_left = correction

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -278,7 +278,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         vecjacobian!(dλ, y, λ, integrator.p, integrator.t, fakeS;
                               dgrad=dgrad, dy=dy)
 
-
+        dgrad .*= -one(eltype(dgrad))
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
           # second correction to correct for left limit
           @unpack Lu_left = correction

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -236,22 +236,22 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
           # user did sol[end] on only_end
           if typeof(_save_idxs) <: Number
             x = vec(Δ[1])
-            _out[_save_idxs] .= .-adapt(outtype,@view(x[_save_idxs]))
+            _out[_save_idxs] .= adapt(outtype,@view(x[_save_idxs]))
           elseif _save_idxs isa Colon
-            vec(_out) .= .-adapt(outtype,vec(Δ[1]))
+            vec(_out) .= adapt(outtype,vec(Δ[1]))
           else
-            vec(@view(_out[_save_idxs])) .= .-adapt(outtype,vec(Δ[1])[_save_idxs])
+            vec(@view(_out[_save_idxs])) .= adapt(outtype,vec(Δ[1])[_save_idxs])
         end
         else
           Δ isa NoTangent && return
           if typeof(_save_idxs) <: Number
             x = vec(Δ)
-            _out[_save_idxs] .= .-adapt(outtype,@view(x[_save_idxs]))
+            _out[_save_idxs] .= adapt(outtype,@view(x[_save_idxs]))
           elseif _save_idxs isa Colon
-            vec(_out) .= .-adapt(outtype,vec(Δ))
+            vec(_out) .= adapt(outtype,vec(Δ))
           else
             x = vec(Δ)
-            vec(@view(_out[_save_idxs])) .= .-adapt(outtype,@view(x[_save_idxs]))
+            vec(@view(_out[_save_idxs])) .= adapt(outtype,@view(x[_save_idxs]))
           end
         end
       else
@@ -259,19 +259,19 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
         if typeof(Δ) <: AbstractArray{<:AbstractArray} || typeof(Δ) <: DESolution
           x = Δ[i]
           if typeof(_save_idxs) <: Number
-            _out[_save_idxs] = .-@view(x[_save_idxs])
+            _out[_save_idxs] = @view(x[_save_idxs])
           elseif _save_idxs isa Colon
-            vec(_out) .= .-vec(x)
+            vec(_out) .= vec(x)
           else
-            vec(@view(_out[_save_idxs])) .= .-vec(@view(x[_save_idxs]))
+            vec(@view(_out[_save_idxs])) .= vec(@view(x[_save_idxs]))
           end
         else
           if typeof(_save_idxs) <: Number
-            _out[_save_idxs] = .-adapt(outtype,reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[_save_idxs, i])
+            _out[_save_idxs] = adapt(outtype,reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[_save_idxs, i])
           elseif _save_idxs isa Colon
-            vec(_out) .= .-vec(adapt(outtype,reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
+            vec(_out) .= vec(adapt(outtype,reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
           else
-            vec(@view(_out[_save_idxs])) .= .-vec(adapt(outtype,reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
+            vec(@view(_out[_save_idxs])) .= vec(adapt(outtype,reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
           end
         end
       end
@@ -600,7 +600,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
         end
         ArrayInterfaceCore.restructure(u0,reduce(vcat,du0parts))
     end
-    
+
     if originator isa SciMLBase.TrackerOriginator || originator isa SciMLBase.ReverseDiffOriginator
       (NoTangent(),NoTangent(),unthunk(du0),unthunk(dp),NoTangent(),ntuple(_->NoTangent(), length(args))...)
     else
@@ -878,19 +878,19 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     function df(_out, u, p, t, i)
       if typeof(Δ) <: AbstractArray{<:AbstractArray} || typeof(Δ) <: DESolution
         if typeof(_save_idxs) <: Number
-          _out[_save_idxs] = -Δ[i][_save_idxs]
+          _out[_save_idxs] = Δ[i][_save_idxs]
         elseif _save_idxs isa Colon
-          vec(_out) .= -vec(Δ[i])
+          vec(_out) .= vec(Δ[i])
         else
-          vec(@view(_out[_save_idxs])) .= -vec(Δ[i][_save_idxs])
+          vec(@view(_out[_save_idxs])) .= vec(Δ[i][_save_idxs])
         end
       else
         if typeof(_save_idxs) <: Number
-          _out[_save_idxs] = -adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[_save_idxs, i])
+          _out[_save_idxs] = adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[_save_idxs, i])
         elseif _save_idxs isa Colon
-          vec(_out) .= -vec(adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
+          vec(_out) .= vec(adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
         else
-          vec(@view(_out[_save_idxs])) .= -vec(adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
+          vec(@view(_out[_save_idxs])) .= vec(adapt(DiffEqBase.parameterless_type(u0),reshape(Δ, prod(size(Δ)[1:end-1]), size(Δ)[end])[:, i]))
         end
       end
     end

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -724,7 +724,7 @@ function accumulate_cost!(dλ, y, p, t, S::TS, dgrad=nothing) where TS<:Sensitiv
   if dg !== nothing
     if !(dg isa Tuple)
       dg(dg_val,y,p,t)
-      dλ .+= vec(dg_val)
+      dλ .-= vec(dg_val)
     else
       dg[1](dg_val[1],y,p,t)
       dλ .+= vec(dg_val[1])

--- a/src/interpolating_adjoint.jl
+++ b/src/interpolating_adjoint.jl
@@ -117,6 +117,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t)
   end
 
   dλ .*= -one(eltype(λ))
+  dgrad .*= -one(eltype(dgrad))
 
   discrete || accumulate_cost!(dλ, y, p, t, S, dgrad)
   return nothing
@@ -130,6 +131,7 @@ function (S::ODEInterpolatingAdjointSensitivityFunction)(du,u,p,t,W)
   vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad, W=W)
 
   dλ .*= -one(eltype(λ))
+  dgrad .*= -one(eltype(dgrad))
 
   discrete || accumulate_cost!(dλ, y, p, t, S, dgrad)
   return nothing

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -128,7 +128,7 @@ function ForwardLSSProblem(sol, sensealg::ForwardLSS, t=nothing, dg = nothing;
   isinplace = DiffEqBase.isinplace(f)
 
   # some shadowing sensealgs require knowledge of g
-  check_for_g(sensealg,g)   
+  check_for_g(sensealg,g)
 
   p === nothing && error("You must have parameters to use parameter sensitivity calculations!")
   !(sol.u isa AbstractVector) && error("`u` has to be an AbstractVector.")
@@ -340,14 +340,14 @@ function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,LSSregulari
       vtmp = @view v[(n0+j-2)*numindvar+1:(n0+j-1)*numindvar]
       #  final gradient result for ith parameter
       accumulate_cost!(dg, u, uf.p, uf.t, sensealg, diffcache, n0+j-1)
-    
+
       if dg_val isa Tuple
         res[i] += dot(dg_val[1], vtmp)
         res[i] += dg_val[2][i]
       else
         res[i] += dot(dg_val, vtmp)
       end
-    
+
     end
     # mean value
     res[i] = res[i]/(n1-n0+1)
@@ -444,11 +444,8 @@ function accumulate_cost!(dg, u, p, t, sensealg::ForwardLSS, diffcache, indx)
     if dg_val isa Tuple
       dg[1](dg_val[1], u, p, nothing, indx) # indx = n0 + j - 1 for LSSregularizer and j for windowing
       dg[2](dg_val[2], u, p, nothing, indx)
-      dg_val[1] .*= -1 # flipped concrete_solve sign 
-      dg_val[2] .*= -1
     else
       dg(dg_val, u, p, nothing, indx)
-      dg_val .*= -1
     end
   end
 
@@ -485,7 +482,7 @@ function AdjointLSSProblem(sol, sensealg::AdjointLSS, t=nothing, dg = nothing;
   isinplace = DiffEqBase.isinplace(f)
 
   # some shadowing sensealgs require knowledge of g
-  check_for_g(sensealg,g) 
+  check_for_g(sensealg,g)
 
   p === nothing && error("You must have parameters to use parameter sensitivity calculations!")
   !(sol.u isa AbstractVector) && error("`u` has to be an AbstractVector.")
@@ -575,10 +572,10 @@ function wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
     else
       if dg_val isa Tuple
         dg[1](dg_val[1],u,uf.p,nothing,i)
-        @. _wBinv = -_wBinv*dg_val[1]/Nt
+        @. _wBinv = _wBinv*dg_val[1]/Nt
       else
         dg(dg_val,u,uf.p,nothing,i)
-        @. _wBinv = -_wBinv*dg_val/Nt
+        @. _wBinv = _wBinv*dg_val/Nt
       end
     end
   end
@@ -614,7 +611,7 @@ function shadow_adjoint(prob::AdjointLSSProblem,sensealg::AdjointLSS,LSSregulari
         @. res += dg_val[2]
       else
         dg[2](dg_val[2],u,uf.p,nothing,n0+j-1)
-        @. res -= dg_val[2]
+        @. res += dg_val[2]
       end
     end
     res ./= (size(umidres)[2])

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -185,9 +185,9 @@ function (NS::NILSASSensitivityFunction)(du,u,p,t)
       # j = 1 is the inhomogenous adjoint solution
       if !discrete
         if dg_val isa Tuple
-          dλ .+= vec(dg_val[1])
+          dλ .-= vec(dg_val[1])
         else
-          dλ .+= vec(dg_val)
+          dλ .-= vec(dg_val)
         end
       end
     end
@@ -211,7 +211,7 @@ function (NS::NILSASSensitivityFunction)(du,u,p,t)
   end
 
   if dg_val isa Tuple && !discrete
-    ddJs .= vec(dg_val[2])
+    ddJs .= -vec(dg_val[2])
   end
 
   return nothing

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -185,9 +185,9 @@ function (NS::NILSASSensitivityFunction)(du,u,p,t)
       # j = 1 is the inhomogenous adjoint solution
       if !discrete
         if dg_val isa Tuple
-          dλ .-= vec(dg_val[1])
+          dλ .+= vec(dg_val[1])
         else
-          dλ .-= vec(dg_val)
+          dλ .+= vec(dg_val)
         end
       end
     end
@@ -211,7 +211,7 @@ function (NS::NILSASSensitivityFunction)(du,u,p,t)
   end
 
   if dg_val isa Tuple && !discrete
-    ddJs = -vec(dg_val[2])
+    ddJs .= vec(dg_val[2])
   end
 
   return nothing
@@ -225,11 +225,8 @@ function accumulate_cost!(dg, y, p, t, nilss::NILSSSensitivityFunction)
     if dg_val isa Tuple
       DiffEqSensitivity.gradient!(dg_val[1],pgpu,y,alg,pgpu_config)
       DiffEqSensitivity.gradient!(dg_val[2],pgpp,y,alg,pgpp_config)
-      dg_val[1] .*= -1
-      dg_val[2] .*= -1
     else
       DiffEqSensitivity.gradient!(dg_val,pgpu,y,alg,pgpu_config)
-      dg_val .*= -1
     end
   else
     if dg_val isa Tuple

--- a/src/nilsas.jl
+++ b/src/nilsas.jl
@@ -180,6 +180,7 @@ function (NS::NILSASSensitivityFunction)(du,u,p,t)
     λ,_,_,dλ,dgrad,dy = split_states(du,u,t,NS,j)
     vecjacobian!(dλ, y, λ, p, t, S, dgrad=dgrad, dy=dy)
     dλ .*= -1
+    dgrad .*= -1
 
     if j==1
       # j = 1 is the inhomogenous adjoint solution

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -87,7 +87,7 @@ struct NILSSProblem{A,CacheType,FSprob,probType,u0Type,vstar0Type,w0Type,
 end
 
 
-function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing; 
+function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing;
                             kwargs...)
 
   @unpack f, p, u0, tspan = prob
@@ -97,7 +97,7 @@ function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing;
   numparams = length(p)
 
   # some shadowing sensealgs require knowledge of g
-  check_for_g(sensealg,g) 
+  check_for_g(sensealg,g)
 
   # integer dimension of the unstable subspace
   if nus === nothing
@@ -118,7 +118,7 @@ function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing;
   if t!==nothing
     @assert t isa StepRangeLen
     dt_ts = step(t)
-    @assert dt_ts >= dtsave  
+    @assert dt_ts >= dtsave
     @assert T_seg >= dt_ts
     jevery = Int(dt_ts/dtsave) # will throw an inexact error if dt_ts is not a multiple of dtsave. (could be more sophisticated)
     cur_time = Ref(1)
@@ -159,7 +159,7 @@ function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing;
     rand!(rng,_w)
     normalize!(_w)
   end
-          
+
   vstar0 = zeros(eltype(u0), numindvar*numparams)
   w0 = vec(w[:,1,1,:])
 
@@ -262,10 +262,10 @@ function forward_sense(prob::NILSSProblem,nilss::NILSS,alg)
   for iseg=1:nseg
     # compute y, w, vstar
     # _sol is a numindvar*(1+nus+1) x nstep matrix
-               
+
     dt = (t2 - t1) / (nstep-1)
     _sol = Array(solve(_prob, alg, saveat=t1:dt:t2))
-                    
+
     store_y_w_vstar!(y, w, vstar, _sol, nus, numindvar, numparams, iseg)
 
     # store dudt, objective g (gsave), and its derivative wrt. to u (dgdu)
@@ -347,7 +347,7 @@ function dudt_g_dgdu!(dudt, gsave, dgdu, nilssprob::NILSSProblem, y, p, iseg)
       accumulate_cost!(_dgdu, dg, u, p, nothing, sensealg, diffcache, j)
     end
   end
-  jevery !== nothing && (cur_time[] -= one(jevery)) # interface between segments gets two bumps 
+  jevery !== nothing && (cur_time[] -= one(jevery)) # interface between segments gets two bumps
   return nothing
 end
 
@@ -491,8 +491,8 @@ function compute_xi(ξ,v,dudt,nseg)
 end
 
 function accumulate_cost!(_dgdu, dg, u, p, t, sensealg::NILSS, diffcache::NILSSSensitivityFunction, j)
-  @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config = diffcache 
-  
+  @unpack dg_val, pgpu, pgpu_config, pgpp, pgpp_config = diffcache
+
   if dg===nothing
     if dg_val isa Tuple
       DiffEqSensitivity.gradient!(dg_val[1], pgpu, u, sensealg, pgpu_config)
@@ -504,13 +504,13 @@ function accumulate_cost!(_dgdu, dg, u, p, t, sensealg::NILSS, diffcache::NILSSS
   else
     if dg_val isa Tuple
       dg[1](dg_val[1],u,p,nothing,j)
-      @. _dgdu = -dg_val[1]
+      @. _dgdu = dg_val[1]
     else
       dg(dg_val,u,p,nothing,j)
-      @. _dgdu = -dg_val
+      @. _dgdu = dg_val
     end
   end
-  
+
   return nothing
 end
 

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -333,9 +333,8 @@ function update_integrand_and_dgrad(res,sensealg::QuadratureAdjoint,cb,integrand
 
   # account for implicit events
 
-  dλ .= dλ-integrand.λ
+  @. dλ = -dλ-integrand.λ
   vecjacobian!(dλ, integrand.y, dλ, integrand.p, t, fakeS; dgrad=dgrad)
-  dgrad .*= -one(eltype(dgrad))
   res .-= dgrad
   return integrand
 end

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -174,7 +174,6 @@ function (S::AdjointSensitivityIntegrand)(out,t)
   f = sol.prob.f
   sol(y,t)
   adj_sol(λ,t)
-  λ .*= -one(eltype(λ))
   isautojacvec = get_jacvec(sensealg)
   # y is aliased
 
@@ -280,7 +279,7 @@ function _adjoint_sensitivities(sol,sensealg::QuadratureAdjoint,alg,g,
                        atol=abstol,rtol=reltol)[1]
       end
     end
-    return -adj_sol[end], res
+    return adj_sol[end], res
   end
 end
 

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -335,6 +335,7 @@ function update_integrand_and_dgrad(res,sensealg::QuadratureAdjoint,cb,integrand
 
   dλ .= dλ-integrand.λ
   vecjacobian!(dλ, integrand.y, dλ, integrand.p, t, fakeS; dgrad=dgrad)
+  dgrad .*= -one(eltype(dgrad))
   res .-= dgrad
   return integrand
 end

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -332,7 +332,7 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
 
   p = sol.prob.p
   l = p === nothing || p === DiffEqBase.NullParameters() ? 0 : length(sol.prob.p)
-  du0 = -adj_sol[end][1:length(sol.prob.u0)]
+  du0 = adj_sol[end][1:length(sol.prob.u0)]
 
   if eltype(sol.prob.p) <: real(eltype(adj_sol[end]))
     dp = real.(adj_sol[end][(1:l) .+ length(sol.prob.u0)])'

--- a/src/steadystate_adjoint.jl
+++ b/src/steadystate_adjoint.jl
@@ -179,6 +179,7 @@ end
         @. dg_dp_val = dg_dp_val - vjp
         return dg_dp_val
     else
-        return -vjp
+        vjp .*= -1
+        return vjp
     end
 end

--- a/src/steadystate_adjoint.jl
+++ b/src/steadystate_adjoint.jl
@@ -176,9 +176,9 @@ end
         dg_dp_config = build_grad_config(sensealg, dg_dp, p, p)
         gradient!(dg_dp_val, dg_dp, p, sensealg, dg_dp_config)
 
-        @. dg_dp_val = dg_dp_val - vjp
+        @. dg_dp_val = dg_dp_val + vjp
         return dg_dp_val
     else
-        return -vjp
+        return vjp
     end
 end

--- a/src/steadystate_adjoint.jl
+++ b/src/steadystate_adjoint.jl
@@ -176,9 +176,9 @@ end
         dg_dp_config = build_grad_config(sensealg, dg_dp, p, p)
         gradient!(dg_dp_val, dg_dp, p, sensealg, dg_dp_config)
 
-        @. dg_dp_val = dg_dp_val + vjp
+        @. dg_dp_val = dg_dp_val - vjp
         return dg_dp_val
     else
-        return vjp
+        return -vjp
     end
 end

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -39,7 +39,7 @@ println("Calculate discrete adjoint sensitivities")
 t = 0.0:0.5:10.0
 # g(t,u,i) = (1-u)^2/2, L2 away from 1
 function dg(out,u,p,t,i)
-  (out.=2.0.-u)
+  (out.=-2.0.+u)
 end
 
 _,easy_res = adjoint_sensitivities(sol,Tsit5(),dg,t,abstol=1e-14,
@@ -279,7 +279,7 @@ res4 = ForwardDiff.gradient(p->G(p,t4),[1.5,1.0,3.0,1.0])
 println("Adjoints of u0")
 
 function dg(out,u,p,t,i)
-  out .= 1 .- u
+  out .= -1 .+ u
 end
 
 ū0,adj = adjoint_sensitivities(sol,Tsit5(),dg,t,abstol=1e-14,
@@ -519,7 +519,7 @@ sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
   prob_lorenz = ODEProblem(lorenz, [1.0, 0.0, 0.0], (0, tf), [10, 28, 8/3])
   sol_lorenz = solve(prob_lorenz,Tsit5(),reltol=1e-6,abstol=1e-9)
   function dg(out,u,p,t,i)
-    (out.=2.0.-u)
+    (out.=-2.0.+u)
   end
   t = 0:0.1:tf
   _,easy_res1 = adjoint_sensitivities(sol_lorenz,Tsit5(),dg,t,abstol=1e-6,

--- a/test/adjoint.jl
+++ b/test/adjoint.jl
@@ -619,7 +619,7 @@ sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
 
   int_u0, int_p = adjoint_sensitivities(fwd_sol,Tsit5(),(x, params, t)->cost(x,params), nothing, sensealg=InterpolatingAdjoint())
 
-  @test isapprox(-backsolve_checkpointing_results[1:length(x0)], int_u0, rtol=1e-10)
+  @test isapprox(backsolve_checkpointing_results[1:length(x0)], int_u0, rtol=1e-10)
   @test isapprox(backsolve_checkpointing_results[(1:length(params)) .+ length(x0)], int_p', rtol=1e-10)
 end
 
@@ -648,7 +648,7 @@ using LinearAlgebra, DiffEqSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
     sol_mm = solve(prob_mm, Rodas5(), reltol=1e-14, abstol=1e-14)
 
     ts = 0:0.01:1
-    dg(out,u,p,t,i) = out .= -1
+    dg(out,u,p,t,i) = out .= 1
     _, res = adjoint_sensitivities(sol_mm,alg,dg,ts,abstol=1e-14,reltol=1e-14,sensealg=QuadratureAdjoint())
     reference_sol = ForwardDiff.gradient(p->G(p, prob_mm, ts, sum),vec(p))
     @test res' ≈ reference_sol rtol=1e-11
@@ -706,7 +706,7 @@ using LinearAlgebra, DiffEqSensitivity, OrdinaryDiffEq, ForwardDiff, QuadGK
       prob_singular_mm = ODEProblem(f,[1.0,0.0,0.0],(0.0,100),p)
       sol_singular_mm = solve(prob_singular_mm,Rodas5(autodiff=false),reltol=1e-12,abstol=1e-12)
       ts = [50, sol_singular_mm.t[end]]
-      dg_singular(out,u,p,t,i) = (fill!(out, 0); out[end] = -1)
+      dg_singular(out,u,p,t,i) = (fill!(out, 0); out[end] = 1)
       _, res = adjoint_sensitivities(sol_singular_mm,alg,dg_singular,ts,abstol=1e-8,reltol=1e-8,sensealg=QuadratureAdjoint(),maxiters=Int(1e6))
       reference_sol = ForwardDiff.gradient(p->G(p, prob_singular_mm, ts, sol->sum(last, sol.u)), vec(p))
       @test res' ≈ reference_sol rtol = 1e-5

--- a/test/callbacks/continuous_callbacks.jl
+++ b/test/callbacks/continuous_callbacks.jl
@@ -95,7 +95,7 @@ function test_continuous_callback(cb, g, dg!; only_backsolve=false)
     callback=cb2,
     abstol=abstol, reltol=reltol)
   adj_sol = solve(adj_prob, Tsit5(), abstol=abstol, reltol=reltol)
-  @test du01 ≈ -adj_sol[1:2, end]
+  @test du01 ≈ adj_sol[1:2, end]
   @test dp1 ≈ adj_sol[3:4, end]
 
 
@@ -113,7 +113,7 @@ println("Continuous Callbacks")
   @testset "simple loss function bouncing ball" begin
     g(sol) = sum(sol)
     function dg!(out, u, p, t, i)
-      (out .= -1)
+      (out .= 1)
     end
 
     @testset "callbacks with no effect" begin
@@ -161,7 +161,7 @@ println("Continuous Callbacks")
   end
   @testset "MSE loss function bouncing-ball like" begin
     g(u) = sum((1.0 .- u) .^ 2) ./ 2
-    dg!(out, u, p, t, i) = (out .= 1.0 .- u)
+    dg!(out, u, p, t, i) = (out .= -1.0 .+ u)
     condition(u, t, integrator) = u[1]
     @testset "callback with non-linear affect" begin
       function affect!(integrator)
@@ -183,7 +183,6 @@ println("Continuous Callbacks")
   end
   @testset "MSE loss function free particle" begin
     g(u) = sum((1.0 .- u) .^ 2) ./ 2
-    dg!(out, u, p, t, i) = (out .= 1.0 .- u)
     function fiip(du, u, p, t)
       du[1] = u[2]
       du[2] = 0

--- a/test/callbacks/discrete_callbacks.jl
+++ b/test/callbacks/discrete_callbacks.jl
@@ -108,7 +108,7 @@ function test_discrete_callback(cb, tstops, g, dg!, cboop=nothing, tprev=false)
     callback=cb2,
     abstol=abstol, reltol=reltol)
   adj_sol = solve(adj_prob, Tsit5(), abstol=abstol, reltol=reltol)
-  @test du01 ≈ -adj_sol[1:2, end]
+  @test du01 ≈ adj_sol[1:2, end]
   @test dp1 ≈ adj_sol[3:6, end]
 
 
@@ -127,7 +127,7 @@ end
     @testset "simple loss function" begin
       g(sol) = sum(sol)
       function dg!(out, u, p, t, i)
-        (out .= -1)
+        (out .= 1)
       end
       @testset "callbacks with no effect" begin
         condition(u, t, integrator) = t == 5
@@ -191,7 +191,7 @@ end
     end
     @testset "MSE loss function" begin
       g(u) = sum((1.0 .- u) .^ 2) ./ 2
-      dg!(out, u, p, t, i) = (out .= 1.0 .- u)
+      dg!(out, u, p, t, i) = (out .= -1.0 .+ u)
       @testset "callbacks with no effect" begin
         condition(u, t, integrator) = t == 5
         affect!(integrator) = integrator.u[1] += 0.0

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -28,7 +28,7 @@ sumsol = sum(sol)
 ###
 
 _sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
-ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= -1),0.0:0.1:10,abstol=1e-14,reltol=1e-14)
+ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= 1),0.0:0.1:10,abstol=1e-14,reltol=1e-14)
 du01,dp1 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=QuadratureAdjoint())),u0,p)
 du02,dp2 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=InterpolatingAdjoint())),u0,p)
 du03,dp3 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=BacksolveAdjoint())),u0,p)
@@ -123,7 +123,7 @@ du04,dp4 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14
 ###
 
 _sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
-ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= -1),0.0:0.1:10,abstol=1e-14,reltol=1e-14)
+ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= 1),0.0:0.1:10,abstol=1e-14,reltol=1e-14)
 
 ###
 ### adjoint
@@ -206,7 +206,7 @@ dp2 = ForwardDiff.gradient((p)->sum(last(solve(proboop,Tsit5(),u0=u0,p=p,saveat=
 @test dp1 ≈ dp2
 
 
-# tspan[2]-tspan[1] not a multiple of saveat tests 
+# tspan[2]-tspan[1] not a multiple of saveat tests
 du0,dp = Zygote.gradient((u0,p)->sum(solve(proboop,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=2.3,sensealg=ReverseDiffAdjoint())),u0,p)
 du01,dp1 = Zygote.gradient((u0,p)->sum(solve(proboop,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=2.3,sensealg=QuadratureAdjoint())),u0,p)
 du02,dp2 = Zygote.gradient((u0,p)->sum(solve(proboop,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=2.3,sensealg=InterpolatingAdjoint())),u0,p)
@@ -260,7 +260,7 @@ proboop = SDEProblem(foop,σoop,u0,(0.0,1.0),p)
 ###
 
 _sol = solve(proboop,EulerHeun(),dt=1e-2,adaptive=false,save_noise=true,seed=seed)
-ū0,adj = adjoint_sensitivities(_sol,EulerHeun(),((out,u,p,t,i) -> out .= -1),tarray, sensealg=BacksolveAdjoint())
+ū0,adj = adjoint_sensitivities(_sol,EulerHeun(),((out,u,p,t,i) -> out .= 1),tarray, sensealg=BacksolveAdjoint())
 
 du01,dp1 = Zygote.gradient((u0,p)->sum(solve(proboop,EulerHeun(),
   u0=u0,p=p,dt=1e-2,saveat=0.01,sensealg=BacksolveAdjoint(),seed=seed)),u0,p)

--- a/test/mixed_costs.jl
+++ b/test/mixed_costs.jl
@@ -1,0 +1,179 @@
+using DiffEqSensitivity
+using OrdinaryDiffEq
+using ForwardDiff, FiniteDiff, Zygote
+using QuadGK
+using Test
+
+abstol = 1e-14
+reltol = 1e-14
+savingtimes = collect(1.0:9.0)
+
+function fiip(du, u, p, t)
+  du[1] = dx = p[1] * u[1] - p[2] * u[1] * u[2]
+  du[2] = dy = -p[3] * u[2] + p[4] * u[1] * u[2]
+end
+
+## Continuous cost functionals
+
+function continuous_cost_forward(input)
+  u0 = input[1:2]
+  p = input[3:end]
+
+  prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
+  sol = solve(prob, Tsit5(), abstol=abstol, reltol=reltol)
+  cost, err = quadgk((t) -> sol(t)[1]^2 + p[1], prob.tspan..., atol=abstol, rtol=reltol)
+  cost
+end
+p = [1.5, 1.0, 3.0, 1.0]
+u0 = [1.0; 1.0]
+input = vcat(u0, p)
+
+dForwardDiff = ForwardDiff.gradient(continuous_cost_forward, input)
+dFiniteDiff = FiniteDiff.finite_difference_gradient(continuous_cost_forward, input)
+@test dForwardDiff ≈ dFiniteDiff
+
+prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
+sol = solve(prob, Tsit5(), reltol=reltol, abstol=abstol)
+g(u, p, t) = u[1]^2 + p[1]
+function dgdu(out, u, p, t)
+  out[1] = 2u[1]
+  out[2] = 0.0
+end
+function dgdp(out, u, p, t)
+  out[1] = 1.0
+  out[2] = 0.0
+  out[3] = 0.0
+  out[4] = 0.0
+end
+
+# BacksolveAdjoint, all vjps
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=BacksolveAdjoint(autojacvec=EnzymeVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=BacksolveAdjoint(autojacvec=ReverseDiffVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=BacksolveAdjoint(autojacvec=TrackerVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=BacksolveAdjoint(autojacvec=false), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+
+# InterpolatingAdjoint, all vjps
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=InterpolatingAdjoint(autojacvec=EnzymeVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=InterpolatingAdjoint(autojacvec=TrackerVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=InterpolatingAdjoint(autojacvec=false), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+
+# QuadratureAdjoint, all vjps
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=QuadratureAdjoint(autojacvec=EnzymeVJP(), abstol=abstol, reltol=reltol), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=QuadratureAdjoint(autojacvec=ReverseDiffVJP(), abstol=abstol, reltol=reltol), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), g, nothing, (dgdu, dgdp), sensealg=QuadratureAdjoint(autojacvec=false, abstol=abstol, reltol=reltol), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+##
+
+## Discrete costs
+
+function discrete_cost_forward(input, sensealg=nothing)
+  u0 = input[1:2]
+  p = input[3:end]
+
+  prob = ODEProblem(fiip, u0, (0.0, 10.0), p)
+  sol = Array(solve(prob, Tsit5(), abstol=abstol, reltol=reltol, saveat=savingtimes, sensealg=sensealg, save_start=false, save_end=false))
+  cost = zero(eltype(p))
+  for u in eachcol(sol)
+    cost += u[1]^2 #+ p[1]
+  end
+  cost
+end
+dForwardDiff = ForwardDiff.gradient(discrete_cost_forward, input)
+dFiniteDiff = FiniteDiff.finite_difference_gradient(discrete_cost_forward, input)
+@test dForwardDiff ≈ dFiniteDiff
+
+function dgdu(out, u, p, t, i)
+  out[1] = 2u[1]
+  out[2] = 0.0
+end
+function dgdp(out, u, p, t, i)
+  out[1] = 0.0
+  out[2] = 0.0
+  out[3] = 0.0
+  out[4] = 0.0
+end
+
+# BacksolveAdjoint, all vjps
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=BacksolveAdjoint(autojacvec=EnzymeVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=BacksolveAdjoint(autojacvec=ReverseDiffVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=BacksolveAdjoint(autojacvec=TrackerVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=BacksolveAdjoint(autojacvec=false), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+
+# InterpolatingAdjoint, all vjps
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=InterpolatingAdjoint(autojacvec=EnzymeVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=InterpolatingAdjoint(autojacvec=ReverseDiffVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=InterpolatingAdjoint(autojacvec=TrackerVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=InterpolatingAdjoint(autojacvec=false), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP()), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+
+# QuadratureAdjoint, all vjps
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=QuadratureAdjoint(autojacvec=EnzymeVJP(), abstol=abstol, reltol=reltol), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=QuadratureAdjoint(autojacvec=ReverseDiffVJP(), abstol=abstol, reltol=reltol), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+du0, dp = adjoint_sensitivities(sol, Tsit5(), dgdu, savingtimes, sensealg=QuadratureAdjoint(autojacvec=false, abstol=abstol, reltol=reltol), abstol=abstol, reltol=reltol)
+@test du0 ≈ dForwardDiff[1:2]
+@test dp' ≈ dForwardDiff[3:6]
+
+# concrete solve interface
+dZygote = Zygote.gradient(input -> discrete_cost_forward(input, BacksolveAdjoint()), input)[1]
+@test dZygote ≈ dForwardDiff
+dZygote = Zygote.gradient(input -> discrete_cost_forward(input, InterpolatingAdjoint()), input)[1]
+@test dZygote ≈ dForwardDiff
+dZygote = Zygote.gradient(input -> discrete_cost_forward(input, QuadratureAdjoint()), input)[1]
+@test dZygote ≈ dForwardDiff
+##
+
+
+## Mixed costs

--- a/test/rode.jl
+++ b/test/rode.jl
@@ -13,7 +13,7 @@ function g(u,p,t)
 end
 
 function dg!(out,u,p,t,i)
-  (out.=-u)
+  (out.=u)
 end
 
 @testset "noise iip tests" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,7 @@ end
 
 if GROUP == "All" || GROUP == "Core3" || GROUP == "Downstream"
     @time @safetestset "Adjoint Sensitivity" begin include("adjoint.jl") end
+    @time @safetestset "Continuous and discrete costs" begin include("mixed_costs.jl") end
 end
 
 if GROUP == "All" || GROUP == "Core4"

--- a/test/sde_checkpointing.jl
+++ b/test/sde_checkpointing.jl
@@ -20,7 +20,7 @@ function g(u,p,t)
 end
 
 function dg!(out,u,p,t,i)
-  (out.=-u)
+  (out.=u)
 end
 
 p2 = [1.01,0.87]

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -476,7 +476,7 @@ end
 
 
   @test adj_soloop[end][length(p)+length(u₀)+1:end] == soloop.u[1]
-  @test - adj_soloop[end][1:length(u₀)] == res_sde_u0
+  @test adj_soloop[end][1:length(u₀)] == res_sde_u0
   @test adj_soloop[end][length(u₀)+1:end-length(u₀)] == res_sde_p'
 
   adjprob = SDEAdjointProblem(sol,BacksolveAdjoint(autojacvec=ReverseDiffVJP(),noisemixing=true,checkpointing=true),dg!,tarray, nothing)
@@ -509,7 +509,7 @@ end
   adj_soloop = solve(adjproboop,EulerHeun(); dt=dtmix, tstops=soloop.t, adaptive=false)
 
 
-  @test - adj_soloop[end][1:length(u₀)] ≈ res_sde_u0  atol = 1e-14
+  @test adj_soloop[end][1:length(u₀)] ≈ res_sde_u0  atol = 1e-14
   @test adj_soloop[end][length(u₀)+1:end] ≈ res_sde_p' atol = 1e-14
 
   adjprob = SDEAdjointProblem(sol,InterpolatingAdjoint(autojacvec=ReverseDiffVJP(),noisemixing=true,checkpointing=true),dg!,tarray, nothing)

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -20,7 +20,7 @@ function g(u,p,t)
 end
 
 function dg!(out,u,p,t,i)
-  (out.=-u)
+  (out.=u)
 end
 
 # non-diagonal noise

--- a/test/sde_scalar_ito.jl
+++ b/test/sde_scalar_ito.jl
@@ -21,7 +21,7 @@ function g(u,p,t)
 end
 
 function dg!(out,u,p,t,i)
-  (out.=-u)
+  (out.=u)
 end
 
 dt = tend/1e4

--- a/test/sde_scalar_stratonovich.jl
+++ b/test/sde_scalar_stratonovich.jl
@@ -19,7 +19,7 @@ function g(u,p,t)
 end
 
 function dg!(out,u,p,t,i)
-  (out.=-u)
+  (out.=u)
 end
 
 p2 = [1.01,0.87]

--- a/test/sde_stratonovich.jl
+++ b/test/sde_stratonovich.jl
@@ -25,7 +25,7 @@ function g(u,p,t)
 end
 
 function dg!(out,u,p,t,i)
-  (out.=-u)
+  (out.=u)
 end
 
 p2 = [1.01,0.87]

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -190,10 +190,10 @@ using Zygote
     g(u,p,t) = u[end]^2/2 + sum(p)
     function dgu(out,u,p,t,i)
       fill!(out, zero(eltype(u)))
-      out[end] = -u[end]
+      out[end] = u[end]
     end
     function dgp(out,u,p,t,i)
-      fill!(out, -one(eltype(p)))
+      fill!(out, one(eltype(p)))
     end
 
     function G(p; sensealg=ForwardLSS(g=g), dt=0.01)

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -26,7 +26,7 @@ using Zygote
     g(u,p,t) = u[end]
     function dg(out,u,p,t,i)
       fill!(out, zero(eltype(u)))
-      out[end] = -one(eltype(u))
+      out[end] = one(eltype(u))
     end
     lss_problem1 = ForwardLSSProblem(sol_attractor, ForwardLSS(g=g))
     lss_problem1a = ForwardLSSProblem(sol_attractor, ForwardLSS(g=g), nothing, dg)
@@ -131,10 +131,10 @@ using Zygote
     g(u,p,t) = u[end] + sum(p)
     function dgu(out,u,p,t,i)
       fill!(out, zero(eltype(u)))
-      out[end] = -one(eltype(u))
+      out[end] = one(eltype(u))
     end
     function dgp(out,u,p,t,i)
-      fill!(out, -one(eltype(p)))
+      fill!(out, one(eltype(p)))
     end
 
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(LSSregularizer=DiffEqSensitivity.TimeDilation(10.0),g=g))
@@ -272,7 +272,7 @@ end
     g(u,p,t) = u[end]
     function dg(out,u,p,t,i)
       fill!(out, zero(eltype(u)))
-      out[end] = -one(eltype(u))
+      out[end] = one(eltype(u))
     end
 
     nseg = 50 # number of segments on time interval
@@ -304,13 +304,13 @@ end
   end
 
   @testset "Lorenz" begin
-    # Here we test LSS output to NILSS output w/ multiple params 
+    # Here we test LSS output to NILSS output w/ multiple params
     function lorenz!(du,u,p,t)
       du[1] = p[1]*(u[2]-u[1])
       du[2] = u[1]*(p[2]-u[3]) - u[2]
       du[3] = u[1]*u[2] - p[3]*u[3]
     end
-    
+
     p = [10.0, 28.0, 8/3]
     u0 = rand(3)
 
@@ -324,29 +324,29 @@ end
 
     prob_attractor = ODEProblem(lorenz!,sol_init[end],tspan_attractor,p)
     sol_attractor = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14)
-    
+
     g(u,p,t) = u[end]
-    
+
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(LSSregularizer=DiffEqSensitivity.TimeDilation(10.0),g=g))
-    
+
     resfw = shadow_forward(lss_problem)
-    
+
     # NILSS can handle w/ longer timespan and get lower noise in sensitivity estimate
     tspan_init = (0.0,100.0)
     tspan_attractor = (100.0,150.0)
-    
+
     prob_init = ODEProblem(lorenz!,u0,tspan_init,p)
     sol_init = solve(prob_init,Tsit5())
-    
+
     prob_attractor = ODEProblem(lorenz!,sol_init[end],tspan_attractor,p)
     sol_attractor = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14)
-    
+
     nseg = 50 # number of segments on time interval
     nstep = 2001 # number of steps on each segment
-    
+
     nilss_prob = NILSSProblem(prob_attractor, NILSS(nseg, nstep; g));
     res = shadow_forward(nilss_prob, Tsit5())
-    
+
     # There is larger noise in LSS estimate of parameter 3 due to shorter timespan considered,
     # so test tolerance for parameter 3 is larger.
     @test resfw[1] ≈ res[1] atol=5e-2
@@ -428,7 +428,7 @@ end
     g(u,p,t) = u[end]
     function dg(out,u,p,t,i=nothing)
       fill!(out, zero(eltype(u)))
-      out[end] = -one(eltype(u))
+      out[end] = one(eltype(u))
     end
 
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(LSSregularizer=DiffEqSensitivity.TimeDilation(10.0), g=g), nothing, dg)
@@ -480,10 +480,10 @@ end
     g(u,p,t) = u[end]^2/2 + sum(p)
     function dgu(out,u,p,t,i=nothing)
       fill!(out, zero(eltype(u)))
-      out[end] = -u[end]
+      out[end] = u[end]
     end
     function dgp(out,u,p,t,i=nothing)
-      fill!(out, -one(eltype(p)))
+      fill!(out, one(eltype(p)))
     end
 
     lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(LSSregularizer=DiffEqSensitivity.TimeDilation(10.0), g=g), nothing, (dgu,dgp))


### PR DESCRIPTION
Looking into https://github.com/SciML/DiffEqSensitivity.jl/issues/543
Example for once branch, all the other branches need to have their signs swapped also.

I think the issue is that you can either define the adjoint equation as:
`d lambda = -A*lambda -B`
or reparametrized as `gamma = -lambda `
`d gamma = -A*gamma +B`
and the code uses both versions (but calls everything lambda), the signs in `d grad` depend  on which version you use, for continuous cost functions gamma was assumed and was also correctly passed, while for discrete cost functions lambda was assumed, but gamma was passed. I suggest switching everything to assuming lambda (because that is how I see it done in optimal control books). If there is a hack in concrete solve that fixes this issue it will have to be removed, but I don't know where that is located.

```jl
using DiffEqSensitivity
using OrdinaryDiffEq
using ForwardDiff
function fiip(du,u,p,t)
    du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
    du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
end

function cost_forward(input)
    u0 = input[1:2]
    p = input[3:end]

    prob = ODEProblem(fiip,u0,(0.0,10.0),p)
    sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
    cost = zero(eltype(p))
    for t = 0:0.01:10.0
       cost += (sol(t)[1]^2 + p[1])*0.01
    end
    cost
end
p = [1.5,1.0,3.0,1.0];
u0 = [1.0;1.0];
input = vcat(u0,p)

ForwardDiff.gradient(cost_forward,input)
#= 4-element Vector{Float64}:
  -71.92545923275867
  -18.013666752777436
  -19.780018103016378
  -18.01366675277761
   91.50591475972585
 -330.49918845227745
 =#

prob = ODEProblem(fiip,u0,(0.0,10.0),p)
sol = solve(prob,Tsit5(),reltol=1e-14,abstol=1e-14)
g(u,p,t) = u[1]^2 + p[1]
function dgdu(out,u,p,t)
  out[1] = 2u[1]
  out[2] = 0.0
end
function dgdp(out,u,p,t)
  out[1] = 1.0
  out[2] = 0.0
  out[2] = 0.0
  out[2] = 0.0
end

du0,dp = adjoint_sensitivities(sol,Tsit5(),g,nothing,(dgdu,dgdp),sensealg=QuadratureAdjoint(),abstol=1e-14,reltol=1e-14)
#([-71.95379975016145, -18.015832635730415], [-19.809511715740577 -18.01613240466981 91.49995776597893 -330.5063153397706])


function cost_forward(input)
  u0 = input[1:2]
  p = input[3:end]

  prob = ODEProblem(fiip,u0,(0.0,10.0),p)
  sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
  cost = zero(eltype(p))
  for t = 1.0:9.0
     cost += sol(t)[1]^2 #+ p[1]
  end
  cost
end
ForwardDiff.gradient(cost_forward,input)
# with p[1]
#= 6-element Vector{Float64}:
  -45.75266688665985
  -21.217655577397284
   40.388411700615876
  -21.217655577397277
  101.53385018713378
 -302.9410227368751
 =#
# without p[1]
#=  6-element Vector{Float64}:
 -45.75266688665985
 -21.217655577397284
  31.388411700615876
 -21.217655577397277
 101.53385018713378
-302.9410227368751
 =#

g(u,p,t) = u[1]^2 #+ p[1]
function dgdu(out,u,p,t,i)
  out[1] = 2u[1]
  out[2] = 0.0
end
function dgdp(out,u,p,t,i) # don't know how to pass this so can't be sure if more sign changes are needed for this
  out[1] = 1.0
  out[2] = 0.0
  out[2] = 0.0
  out[2] = 0.0
end

du0,dp = adjoint_sensitivities(sol,Tsit5(),dgdu,1.0:9.0,abstol=1e-3,reltol=1e-3,sensealg=QuadratureAdjoint())
# ([-45.43427809297227, -21.209701202168834], [31.885996129674837 -21.176751357966683 101.5737226156943 -302.5700510411537])
```




