### PR TITLE
Reshape state of BacksolveAdjoint to match shape of forward pass

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -173,7 +173,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         tprev = get_tprev(cb,indx,pos_neg)
 
         function w(du,u,p,t,tprev,pos_neg)
-          _affect! = get_affect!(cb.affect!,pos_neg)
+          _affect! = get_affect!(cb,pos_neg)
           fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
           _affect!(fakeinteg)
           du .= fakeinteg.u
@@ -238,7 +238,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
           if !(sensealg isa QuadratureAdjoint)
             
             function wp(dp,p,u,t,tprev,pos_neg)
-              _affect! = get_affect!(cb.affect!,pos_neg)
+              _affect! = get_affect!(cb,pos_neg)
               fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
               _affect!(fakeinteg)
               dp .= fakeinteg.p
@@ -431,7 +431,8 @@ end
 DiffEqBase.terminate!(i::FakeIntegrator) = nothing
 
 # get the affect function of the callback. For example, allows us to get the `f` in PeriodicCallback without the integrator.tstops handling.  
-get_affect!(affect!,pos_neg::Bool) = pos_neg ? get_affect!(affect!.affect!) : get_affect!(affect!.affect_neg!)
-get_affect!(affect!) = affect!
-get_affect!(affect!::DiffEqCallbacks.PeriodicCallbackAffect,pos_neg) = affect!.affect!
+get_affect!(cb::DiscreteCallback,bool) = get_affect!(cb.affect!)
+get_affect!(cb::ContinuousCallback,bool) = bool ? get_affect!(cb.affect!) : get_affect!(cb.affect_neg!)
+get_affect!(affect!::TrackedAffect) = affect!.affect!
+get_affect!(affect!::DiffEqCallbacks.PeriodicCallbackAffect) = affect!.affect!
 

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -433,6 +433,7 @@ DiffEqBase.terminate!(i::FakeIntegrator) = nothing
 # get the affect function of the callback. For example, allows us to get the `f` in PeriodicCallback without the integrator.tstops handling.  
 get_affect!(cb::DiscreteCallback,bool) = get_affect!(cb.affect!)
 get_affect!(cb::ContinuousCallback,bool) = bool ? get_affect!(cb.affect!) : get_affect!(cb.affect_neg!)
-get_affect!(affect!::TrackedAffect) = affect!.affect!
+get_affect!(affect!::TrackedAffect) = get_affect!(affect!.affect!)
+get_affect!(affect!) = affect!
 get_affect!(affect!::DiffEqCallbacks.PeriodicCallbackAffect) = affect!.affect!
 

--- a/src/quadrature_adjoint.jl
+++ b/src/quadrature_adjoint.jl
@@ -310,8 +310,8 @@ function update_integrand_and_dgrad(res,sensealg::QuadratureAdjoint,cb,integrand
   tprev = get_tprev(cb,indx,pos_neg)
 
   function wp(dp,p,u,t,tprev,pos_neg)
-    _affect! = get_affect!(cb.affect!,pos_neg)
-    fakeinteg = FakeIntegrator([x for x in _u],[x for x in p],t,tprev)
+    _affect! = get_affect!(cb,pos_neg)
+    fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
     _affect!(fakeinteg)
     dp .= fakeinteg.p
   end
@@ -328,8 +328,8 @@ function update_integrand_and_dgrad(res,sensealg::QuadratureAdjoint,cb,integrand
   end
 
   function w(du,u,p,t,tprev,pos_neg)
-    _affect! = get_affect!(cb.affect!,pos_neg)
-    fakeinteg = FakeIntegrator([x for x in _u],[x for x in p],t,tprev)
+    _affect! = get_affect!(cb,pos_neg)
+    fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
     _affect!(fakeinteg)
     du .= vec(fakeinteg.u)
   end


### PR DESCRIPTION
Fixes: https://github.com/SciML/DiffEqSensitivity.jl/issues/555

For matrix-valued initial conditions, callbacks can be defined with respect to a matrix interpretation. In `BacksolveAdjoint()`, we solve the vectorized form backwards. This resulted in the BoundsError in https://github.com/SciML/DiffEqSensitivity.jl/issues/555. Therefore, we need to reshape the state to match the definition within the callback. 

In addition, this PR corrects the selection of the affect function for continuous callbacks.

CC: @timkimd 