### PR TITLE
Fix shadowing tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,23 @@ steps:
     # Don't run Buildkite if the commit message includes the text [skip tests]
     if: build.message !~ /\[skip tests\]/
 
+  - label: "Shadowing"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1"
+      - JuliaCI/julia-test#v1:
+          coverage: false
+          julia_args: "--threads=auto"
+    agents:
+      os: "linux"
+      queue: "juliaecosystem"
+      exclusive: true
+    env:
+      GROUP: 'Shadowing'
+    timeout_in_minutes: 120
+    # Don't run Buildkite if the commit message includes the text [skip tests]
+    if: build.message !~ /\[skip tests\]/
+
   - label: "Julia 1"
     plugins:
       - JuliaCI/julia#v1:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
           - Core1
           - Core2
           - Core3
-          - Core4
           - SDE1
           - SDE2
           - SDE3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         group:
           - Core1

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -690,6 +690,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
                                  u0,p,args...;save_start=true,save_end=true,
                                  saveat = eltype(prob.tspan)[],
                                  save_idxs = nothing,
+                                 g = nothing,
                                  t0skip=zero(eltype(prob.tspan)), t1skip=zero(eltype(prob.tspan)),
                                  kwargs...)
 
@@ -697,12 +698,6 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     error("Sensitivity analysis based on Least Squares Shadowing is not compatible with callbacks. Please select another `sensealg`.")
   else
     _prob = remake(prob,u0=u0,p=p)
-  end
-
-  if haskey(kwargs, :g)
-    g = kwargs[:g]
-  else
-    g = nothing
   end
 
   # some shadowing sensealgs require knowledge of g

--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -690,8 +690,6 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
                                  u0,p,args...;save_start=true,save_end=true,
                                  saveat = eltype(prob.tspan)[],
                                  save_idxs = nothing,
-                                 g = nothing,
-                                 t0skip=zero(eltype(prob.tspan)), t1skip=zero(eltype(prob.tspan)),
                                  kwargs...)
 
   if haskey(kwargs, :callback)
@@ -699,9 +697,6 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
   else
     _prob = remake(prob,u0=u0,p=p)
   end
-
-  # some shadowing sensealgs require knowledge of g
-  check_for_g(sensealg,g)
 
   sol = solve(_prob,alg,args...;save_start=save_start,save_end=save_end,saveat=saveat,kwargs...)
 
@@ -768,16 +763,16 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
     end
 
     if sensealg isa ForwardLSS
-      lss_problem = ForwardLSSProblem(sol, sensealg, g, ts, df)
-      dp = shadow_forward(lss_problem; t0skip=t0skip, t1skip=t1skip)
+      lss_problem = ForwardLSSProblem(sol, sensealg, ts, df)
+      dp = shadow_forward(lss_problem)
     elseif sensealg isa AdjointLSS
-      adjointlss_problem = AdjointLSSProblem(sol, sensealg, g, ts, df)
-      dp = shadow_adjoint(adjointlss_problem; t0skip=t0skip, t1skip=t1skip)
+      adjointlss_problem = AdjointLSSProblem(sol, sensealg, ts, df)
+      dp = shadow_adjoint(adjointlss_problem)
     elseif sensealg isa NILSS
-      nilss_prob = NILSSProblem(_prob, sensealg, g, ts, df)
+      nilss_prob = NILSSProblem(_prob, sensealg, ts, df)
       dp = shadow_forward(nilss_prob,alg)
     elseif sensealg isa NILSAS
-      nilsas_prob = NILSASProblem(_prob, sensealg, g, ts, df)
+      nilsas_prob = NILSASProblem(_prob, sensealg, ts, df)
       dp = shadow_adjoint(nilsas_prob,alg)
     else
       error("No concrete_solve implementation found for sensealg `$sensealg`. Did you spell the sensitivity algorithm correctly? Please report this error.")

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -87,14 +87,17 @@ struct NILSSProblem{A,CacheType,FSprob,probType,u0Type,vstar0Type,w0Type,
 end
 
 
-function NILSSProblem(prob, sensealg::NILSS, g, t=nothing, dg = nothing; nus = nothing,
+function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing; nus = nothing,
                             kwargs...)
 
   @unpack f, p, u0, tspan = prob
-  @unpack nseg, nstep, rng = sensealg  #number of segments on time interval, number of steps saved on each segment
+  @unpack nseg, nstep, rng, g = sensealg  #number of segments on time interval, number of steps saved on each segment
 
   numindvar = length(u0)
   numparams = length(p)
+
+  # some shadowing sensealgs require knowledge of g
+  check_for_g(sensealg,g) 
 
   # integer dimension of the unstable subspace
   if nus === nothing
@@ -510,8 +513,8 @@ function accumulate_cost!(_dgdu, dg, u, p, t, sensealg::NILSS, diffcache::NILSSS
   return nothing
 end
 
-function shadow_forward(prob::NILSSProblem,alg)
-  shadow_forward(prob,prob.sensealg,alg)
+function shadow_forward(prob::NILSSProblem,alg; sensealg=prob.sensealg)
+  shadow_forward(prob,sensealg,alg)
 end
 
 function shadow_forward(prob::NILSSProblem,sensealg::NILSS,alg)
@@ -556,4 +559,4 @@ function shadow_forward(prob::NILSSProblem,sensealg::NILSS,alg)
   return res
 end
 
-check_for_g(sensealg::NILSS,g) = (g===nothing && error("To use NILSS, g must be passed as a kwarg."))
+check_for_g(sensealg::NILSS,g) = (g===nothing && error("To use NILSS, g must be passed as a kwarg to `NILSS(g=g)`."))

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -28,8 +28,7 @@ sumsol = sum(sol)
 ###
 
 _sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
-ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= -1),0.0:0.1:10,abstol=1e-14,
-                                  reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
+ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= -1),0.0:0.1:10,abstol=1e-14,reltol=1e-14)
 du01,dp1 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=QuadratureAdjoint())),u0,p)
 du02,dp2 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=InterpolatingAdjoint())),u0,p)
 du03,dp3 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,sensealg=BacksolveAdjoint())),u0,p)
@@ -124,8 +123,7 @@ du04,dp4 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14
 ###
 
 _sol = solve(prob,Tsit5(),abstol=1e-14,reltol=1e-14)
-ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= -1),0.0:0.1:10,abstol=1e-14,
-                                  reltol=1e-14,iabstol=1e-14,ireltol=1e-12)
+ū0,adj = adjoint_sensitivities(_sol,Tsit5(),((out,u,p,t,i) -> out .= -1),0.0:0.1:10,abstol=1e-14,reltol=1e-14)
 
 ###
 ### adjoint

--- a/test/concrete_solve_derivatives.jl
+++ b/test/concrete_solve_derivatives.jl
@@ -74,7 +74,7 @@ du07,dp7 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14
 @test_broken du08,dp8 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,save_idxs = 1:1,sensealg=ForwardSensitivity())),u0,p)
 du09,dp9 = Zygote.gradient((u0,p)->sum(solve(prob,Tsit5(),u0=u0,p=p,abstol=1e-14,reltol=1e-14,saveat=0.1,save_idxs = 1:1,sensealg=ForwardDiffSensitivity())),u0,p)
 
-@test du06 isa ChainRulesCore.NotImplemented
+@test du06 isa Nothing
 @test ū0 ≈ du07 rtol=1e-12
 @test adj ≈ dp6' rtol=1e-12
 @test adj ≈ dp7' rtol=1e-12

--- a/test/downstream/HybridNODE.jl
+++ b/test/downstream/HybridNODE.jl
@@ -10,8 +10,8 @@ function test_hybridNODE(sensealg)
     target = 3.0*(1:datalength)./datalength  # some dummy data to fit to
     cbinput = rand(1, datalength) #some external ODE contribution
     pmodel = Chain(
-        Dense(2, 10, initW=zeros),
-        Dense(10, 2, initW=zeros))
+        Dense(2, 10, init=zeros),
+        Dense(10, 2, init=zeros))
     p, re = Flux.destructure(pmodel)
     dudt(u,p,t) = re(p)(u)
 

--- a/test/downstream/sde_neural.jl
+++ b/test/downstream/sde_neural.jl
@@ -6,6 +6,9 @@ using DiffEqSensitivity
 using DiffEqBase.EnsembleAnalysis
 using Zygote
 
+using Random
+Random.seed!(238248735)
+
 @testset "Neural SDE" begin
     function sys!(du, u, p, t)
         r, e, μ, h, ph, z, i = p

--- a/test/downstream/sde_neural.jl
+++ b/test/downstream/sde_neural.jl
@@ -131,19 +131,19 @@ Random.seed!(238248735)
         end
         false
     end
-
+    println("Test mutating form")
     res1 = DiffEqFlux.sciml_train(
         loss,
         α,
-        ADAM(0.1),
+        ADAM(0.001),
         cb = callback,
         maxiters = 200,
     )
-
+    println("Test non-mutating form")
     res2 = DiffEqFlux.sciml_train(
         loss_op,
         α,
-        ADAM(0.1),
+        ADAM(0.001),
         cb = callback,
         maxiters = 200,
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,11 +42,7 @@ if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("second_order_odes.jl") end
 end
 
-if GROUP == "All" || GROUP == "Core3"
-    @time @safetestset "Shadowing Tests" begin include("shadowing.jl") end
-end
-
-if GROUP == "All" || GROUP == "Core4" || GROUP == "Downstream"
+if GROUP == "All" || GROUP == "Core3" || GROUP == "Downstream"
     @time @safetestset "Adjoint Sensitivity" begin include("adjoint.jl") end
 end
 
@@ -79,6 +75,9 @@ if GROUP == "Callbacks"
     @time @safetestset "Callbacks with Adjoints" begin include("callbacks.jl") end
 end
 
+if GROUP == "Shadowing"
+    @time @safetestset "Shadowing Tests" begin include("shadowing.jl") end
+end
 
 
 if GROUP == "GPU"

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -28,15 +28,15 @@ using Zygote
       fill!(out, zero(eltype(u)))
       out[end] = -one(eltype(u))
     end
-    lss_problem1 = ForwardLSSProblem(sol_attractor, ForwardLSS(), g)
-    lss_problem1a = ForwardLSSProblem(sol_attractor, ForwardLSS(), nothing, nothing, dg)
-    lss_problem2 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), g)
-    lss_problem2a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), nothing, nothing, dg)
-    lss_problem3 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g)
-    lss_problem3a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, nothing, dg) #ForwardLSS with time dilation requires knowledge of g
+    lss_problem1 = ForwardLSSProblem(sol_attractor, ForwardLSS(g=g))
+    lss_problem1a = ForwardLSSProblem(sol_attractor, ForwardLSS(), nothing, dg)
+    lss_problem2 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing(),g=g))
+    lss_problem2a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), nothing, dg)
+    lss_problem3 = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10,g=g))
+    lss_problem3a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10,g=g), nothing, dg) #ForwardLSS with time dilation requires knowledge of g
 
-    adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
-    adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, nothing, dg)
+    adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0,g=g))
+    adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0,g=g), nothing, dg)
 
     res1 = shadow_forward(lss_problem1)
     res1a = shadow_forward(lss_problem1a)
@@ -60,15 +60,15 @@ using Zygote
 
     # fixed saveat to compare with concrete solve
     sol_attractor2 = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14, saveat=0.01)
-    lss_problem1 = ForwardLSSProblem(sol_attractor2, ForwardLSS(), g)
-    lss_problem1a = ForwardLSSProblem(sol_attractor2, ForwardLSS(), nothing, nothing, dg)
-    lss_problem2 = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), g)
-    lss_problem2a = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), nothing, nothing, dg)
-    lss_problem3 = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10), g)
-    lss_problem3a = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10), g, nothing, dg) #ForwardLSS with time dilation requires knowledge of g
+    lss_problem1 = ForwardLSSProblem(sol_attractor2, ForwardLSS(g=g))
+    lss_problem1a = ForwardLSSProblem(sol_attractor2, ForwardLSS(), nothing, dg)
+    lss_problem2 = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing(),g=g))
+    lss_problem2a = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing()), nothing, dg)
+    lss_problem3 = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10,g=g))
+    lss_problem3a = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10,g=g), nothing, dg) #ForwardLSS with time dilation requires knowledge of g
 
-    adjointlss_problem = AdjointLSSProblem(sol_attractor2, AdjointLSS(alpha=10.0), g)
-    adjointlss_problem_a = AdjointLSSProblem(sol_attractor2, AdjointLSS(alpha=10.0), g, nothing, dg)
+    adjointlss_problem = AdjointLSSProblem(sol_attractor2, AdjointLSS(alpha=10.0,g=g))
+    adjointlss_problem_a = AdjointLSSProblem(sol_attractor2, AdjointLSS(alpha=10.0,g=g), nothing, dg)
 
     res1 = shadow_forward(lss_problem1)
     res1a = shadow_forward(lss_problem1a)
@@ -90,9 +90,9 @@ using Zygote
     @test res3 ≈ res4 atol=1e-10
     @test res3 ≈ res4a atol=1e-10
 
-    function G(p; sensealg=ForwardLSS(), dt=0.01, g=nothing)
+    function G(p; sensealg=ForwardLSS(), dt=0.01)
       _prob = remake(prob_attractor,p=p)
-      _sol = solve(_prob,Vern9(),abstol=1e-14,reltol=1e-14,saveat=dt,sensealg=sensealg, g=g)
+      _sol = solve(_prob,Vern9(),abstol=1e-14,reltol=1e-14,saveat=dt,sensealg=sensealg)
       sum(getindex.(_sol.u,3))
     end
 
@@ -102,10 +102,10 @@ using Zygote
     dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=DiffEqSensitivity.Cos2Windowing())),p)
     @test res2 ≈ dp1[1] atol=1e-10
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10,g=g)),p)
     @test res3 ≈ dp1[1] atol=1e-10
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0,g=g)),p)
     @test res4 ≈ dp1[1] atol=1e-10
 
     @show res1[1] res2[1] res3[1]
@@ -137,10 +137,10 @@ using Zygote
       fill!(out, -one(eltype(p)))
     end
 
-    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g)
-    lss_problem_a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, nothing, (dgu,dgp))
-    adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
-    adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, nothing, (dgu,dgp))
+    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10,g=g))
+    lss_problem_a = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10,g=g), nothing, (dgu,dgp))
+    adjointlss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0,g=g))
+    adjointlss_problem_a = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0,g=g), nothing, (dgu,dgp))
 
     resfw = shadow_forward(lss_problem)
     resfw_a = shadow_forward(lss_problem_a)
@@ -152,19 +152,19 @@ using Zygote
     @test resfw ≈ resadj_a rtol=1e-10
 
     sol_attractor2 = solve(prob_attractor,Vern9(),abstol=1e-14,reltol=1e-14, saveat=0.01)
-    lss_problem = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10), g)
+    lss_problem = ForwardLSSProblem(sol_attractor2, ForwardLSS(alpha=10,g=g))
     resfw = shadow_forward(lss_problem)
 
-    function G(p; sensealg=ForwardLSS(), dt=0.01, g=nothing)
+    function G(p; sensealg=ForwardLSS(), dt=0.01)
       _prob = remake(prob_attractor,p=p)
-      _sol = solve(_prob,Vern9(),abstol=1e-14,reltol=1e-14,saveat=dt,sensealg=sensealg, g=g)
+      _sol = solve(_prob,Vern9(),abstol=1e-14,reltol=1e-14,saveat=dt,sensealg=sensealg)
       sum(getindex.(_sol.u,3)) + sum(p)
     end
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10,g=g)),p)
     @test resfw ≈ dp1[1] atol=1e-10
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0,g=g)),p)
     @test resfw ≈ dp1[1] atol=1e-10
 
     @show resfw
@@ -196,58 +196,58 @@ using Zygote
       fill!(out, -one(eltype(p)))
     end
 
-    function G(p; sensealg=ForwardLSS(), dt=0.01, g=nothing, t0skip=0.0, t1skip=0.0)
+    function G(p; sensealg=ForwardLSS(), dt=0.01)
       _prob = remake(prob_attractor,p=p)
-      _sol = solve(_prob,Vern9(),abstol=1e-14,reltol=1e-14,saveat=dt,sensealg=sensealg, g=g, t0skip=t0skip, t1skip=t1skip)
+      _sol = solve(_prob,Vern9(),abstol=1e-14,reltol=1e-14,saveat=dt,sensealg=sensealg)
       sum(getindex.(_sol.u,3).^2)/2 + sum(p)
     end
 
     ## ForwardLSS
 
-    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g)
+    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10, g=g))
     resfw = shadow_forward(lss_problem)
 
     res = deepcopy(resfw)
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10,g=g)),p)
     @test res ≈ dp1[1] atol=1e-10
 
-    resfw = shadow_forward(lss_problem; t0skip=10.0, t1skip=5.0)
+    resfw = shadow_forward(lss_problem, sensealg = ForwardLSS(alpha=10, g=g, t0skip=10.0, t1skip=5.0))
     resskip = deepcopy(resfw)
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10), g=g, t0skip=10.0, t1skip=5.0),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=ForwardLSS(alpha=10, g=g, t0skip=10.0, t1skip=5.0)),p)
     @test resskip ≈ dp1[1] atol=1e-10
 
     @show res resskip
 
     ## ForwardLSS with dgdu and dgdp
 
-    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, nothing, (dgu,dgp))
+    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10,g=g), nothing, (dgu,dgp))
     res2 = shadow_forward(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = shadow_forward(lss_problem; t0skip=10.0, t1skip=5.0)
+    res2 = shadow_forward(lss_problem, sensealg = ForwardLSS(alpha=10.0, t0skip=10.0, t1skip=5.0, g=g))
     @test resskip ≈ res2 atol=1e-10
 
     ## AdjointLSS
 
-    lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g)
+    lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0,g=g))
     res2 = shadow_adjoint(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = shadow_adjoint(lss_problem; t0skip=10.0, t1skip=5.0)
+    res2 = shadow_adjoint(lss_problem, sensealg = AdjointLSS(alpha=10.0, t0skip=10.0, t1skip=5.0, g=g))
     @test_broken resskip ≈ res2 atol=1e-10
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0), g=g),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10.0,g=g)),p)
     @test res ≈ dp1[1] atol=1e-10
 
-    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10), g=g, t0skip=10.0, t1skip=5.0),p)
+    dp1 = Zygote.gradient((p)->G(p, sensealg=AdjointLSS(alpha=10, g=g, t0skip=10.0, t1skip=5.0)),p)
     @test res2 ≈ dp1[1] atol=1e-10
 
     ## AdjointLSS with dgdu and dgd
 
-    lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0), g, nothing, (dgu,dgp))
+    lss_problem = AdjointLSSProblem(sol_attractor, AdjointLSS(alpha=10.0, g=g), nothing, (dgu,dgp))
     res2 = shadow_adjoint(lss_problem)
     @test res ≈ res2 atol=1e-10
-    res2 = shadow_adjoint(lss_problem; t0skip=10.0, t1skip=5.0)
+    res2 = shadow_adjoint(lss_problem, sensealg = AdjointLSS(alpha=10.0, g=g, t0skip=10.0, t1skip=5.0))
     @test_broken resskip ≈ res2 atol=1e-10
   end
 end
@@ -281,11 +281,11 @@ end
     # fix seed here for res1==res2 check, otherwise hom. tangent
     # are initialized randomly
     Random.seed!(1234)
-    nilss_prob1 = NILSSProblem(prob_attractor, NILSS(nseg, nstep), g)
+    nilss_prob1 = NILSSProblem(prob_attractor, NILSS(nseg, nstep, g=g))
     res1 = DiffEqSensitivity.shadow_forward(nilss_prob1,Tsit5())
 
     Random.seed!(1234)
-    nilss_prob2 = NILSSProblem(prob_attractor, NILSS(nseg, nstep), g, nothing, dg)
+    nilss_prob2 = NILSSProblem(prob_attractor, NILSS(nseg, nstep, g=g), nothing, dg)
     res2 = DiffEqSensitivity.shadow_forward(nilss_prob2,Tsit5())
 
     @test res1[1] ≈ 1 atol=5e-2
@@ -294,7 +294,7 @@ end
 
     function G(p; dt=nilss_prob1.dtsave)
       _prob = remake(prob_attractor,p=p)
-      _sol = solve(_prob,Tsit5(),saveat=dt,sensealg=NILSS(nseg, nstep), g=g)
+      _sol = solve(_prob,Tsit5(),saveat=dt,sensealg=NILSS(nseg, nstep, g=g))
       sum(getindex.(_sol.u,3))
     end
 
@@ -380,19 +380,19 @@ end
       out[end] = -one(eltype(u))
     end
 
-    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, nothing, dg)
+    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10, g=g), nothing, dg)
     resfw = shadow_forward(lss_problem)
 
     @info resfw
 
-    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M), g)
+    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M, g=g))
     res = shadow_adjoint(nilsas_prob, Tsit5())
 
     @info res
 
     @test resfw ≈ res atol=1e-1
 
-    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M), g, nothing, dg)
+    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M, g=g), nothing, dg)
     res = shadow_adjoint(nilsas_prob, Tsit5())
 
     @info res
@@ -435,19 +435,19 @@ end
       fill!(out, -one(eltype(p)))
     end
 
-    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10), g, nothing, (dgu,dgp))
+    lss_problem = ForwardLSSProblem(sol_attractor, ForwardLSS(alpha=10, g=g), nothing, (dgu,dgp))
     resfw = shadow_forward(lss_problem)
 
     @info resfw
 
-    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M), g)
+    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M, g=g))
     res = shadow_adjoint(nilsas_prob, Tsit5())
 
     @info res
 
     @test resfw ≈ res rtol=1e-1
 
-    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M), g, nothing, (dgu,dgp))
+    nilsas_prob = NILSASProblem(sol_attractor, NILSAS(nseg,nstep,M, g=g), nothing, (dgu,dgp))
     res = shadow_adjoint(nilsas_prob, Tsit5())
 
     @info res

--- a/test/shadowing.jl
+++ b/test/shadowing.jl
@@ -1,12 +1,12 @@
 using Random; Random.seed!(1238)
 using OrdinaryDiffEq
 using Statistics
-using ForwardDiff, Calculus
 using DiffEqSensitivity
 using Test
 using Zygote
 
 @testset "LSS" begin
+  @info "LSS"
   @testset "Lorentz single parameter" begin
     function lorenz!(du,u,p,t)
       du[1] = 10*(u[2]-u[1])
@@ -253,6 +253,7 @@ using Zygote
 end
 
 @testset "NILSS" begin
+  @info "NILSS"
   @testset "Lorentz single parameter" begin
     function lorenz!(du,u,p,t)
       du[1] = 10*(u[2]-u[1])
@@ -304,6 +305,7 @@ end
 end
 
 @testset "NILSAS" begin
+  @info "NILSAS"
   @testset "nilsas_min function" begin
     u0 = rand(3)
     M = 2


### PR DESCRIPTION
Shadowing tests were found to fail with 

```julia
ERROR: Package DiffEqSensitivity errored during testing (received signal: KILL)
Stacktrace:
 [1] pkgerror(msg::String)
```
in recent PRs, see #568 and #565. This PR is intended to fix this test failure, which is (probably) a memory problem.
