### PR TITLE
update ForwardLSS and AdjointLSS

### DIFF
--- a/src/lss.jl
+++ b/src/lss.jl
@@ -198,7 +198,7 @@ function LSSSchur(dt,u0,numindvar,Nt,Ndt,LSSregularizer::TimeDilation)
   LSSSchur(wBinv,wEinv,B,E)
 end
 
-function LSSSchur(dt,u0,numindvar,Nt,Ndt,LSSregularizer::Union{CosWindowing,Cos2Windowing})
+function LSSSchur(dt,u0,numindvar,Nt,Ndt,LSSregularizer::AbstractCosWindowing)
   wBinv = similar(dt,numindvar*Nt)
   wEinv = nothing
   E = nothing
@@ -238,7 +238,7 @@ function wB!(S::LSSSchur,Δt,Nt,numindvar,dt)
   return nothing
 end
 
-wE!(S::LSSSchur,Δt,dt,LSSregularizer::Union{CosWindowing,Cos2Windowing}) = nothing
+wE!(S::LSSSchur,Δt,dt,LSSregularizer::AbstractCosWindowing) = nothing
 
 function wE!(S::LSSSchur,Δt,dt,LSSregularizer::TimeDilation)
   @unpack wEinv = S
@@ -267,7 +267,7 @@ function B!(S::LSSSchur,dt,umid,sense,sensealg)
   return nothing
 end
 
-E!(S::LSSSchur,dudt,LSSregularizer::Union{CosWindowing,Cos2Windowing}) = nothing
+E!(S::LSSSchur,dudt,LSSregularizer::AbstractCosWindowing) = nothing
 
 function E!(S::LSSSchur,dudt,LSSregularizer::TimeDilation)
   @unpack E = S

--- a/src/lss.jl
+++ b/src/lss.jl
@@ -156,9 +156,9 @@ function ForwardLSSProblem(sol, sensealg::ForwardLSS, t=nothing, dg = nothing;
     @assert sol.t == t
   end
 
-  S = LSSSchur(dt,u0,numindvar,Nt,Ndt,sensealg.alpha)
+  S = LSSSchur(dt,u0,numindvar,Nt,Ndt,sensealg.LSSregularizer)
 
-  if sensealg.alpha isa Number
+  if sensealg.LSSregularizer isa TimeDilation
     η = similar(dt,Ndt)
     window = nothing
     g0 = g(u0,p,tspan[1])
@@ -174,10 +174,10 @@ function ForwardLSSProblem(sol, sensealg::ForwardLSS, t=nothing, dg = nothing;
 
   Δt = tspan[2] - tspan[1]
   wB!(S,Δt,Nt,numindvar,dt)
-  wE!(S,Δt,dt,sensealg.alpha)
-
+  wE!(S,Δt,dt,sensealg.LSSregularizer)
   B!(S,dt,umid,sense,sensealg)
-  E!(S,dudt,sensealg.alpha)
+  E!(S,dudt,sensealg.LSSregularizer)
+
   F = SchurLU(S)
 
   res = similar(u0, numparams)
@@ -189,20 +189,23 @@ function ForwardLSSProblem(sol, sensealg::ForwardLSS, t=nothing, dg = nothing;
     window,Δt,Nt,g0,g,dg,res)
 end
 
-function LSSSchur(dt,u0,numindvar,Nt,Ndt,alpha)
+function LSSSchur(dt,u0,numindvar,Nt,Ndt,LSSregularizer::TimeDilation)
   wBinv = similar(dt,numindvar*Nt)
-  if alpha isa Number
-    wEinv = similar(dt,Ndt)
-    E = Matrix{eltype(u0)}(undef,numindvar*Ndt,Ndt)
-  else
-    wEinv = nothing
-    E = nothing
-  end
+  wEinv = similar(dt,Ndt)
+  E = Matrix{eltype(u0)}(undef,numindvar*Ndt,Ndt)
   B = Matrix{eltype(u0)}(undef,numindvar*Ndt,numindvar*Nt)
 
   LSSSchur(wBinv,wEinv,B,E)
 end
 
+function LSSSchur(dt,u0,numindvar,Nt,Ndt,LSSregularizer::Union{CosWindowing,Cos2Windowing})
+  wBinv = similar(dt,numindvar*Nt)
+  wEinv = nothing
+  E = nothing
+  B = Matrix{eltype(u0)}(undef,numindvar*Ndt,numindvar*Nt)
+
+  LSSSchur(wBinv,wEinv,B,E)
+end
 
 # compute discretized reference trajectory
 function discretize_ref_trajectory!(dt, umid, dudt, sol, Ndt)
@@ -235,10 +238,11 @@ function wB!(S::LSSSchur,Δt,Nt,numindvar,dt)
   return nothing
 end
 
-wE!(S::LSSSchur,Δt,dt,alpha::Union{CosWindowing,Cos2Windowing}) = nothing
+wE!(S::LSSSchur,Δt,dt,LSSregularizer::Union{CosWindowing,Cos2Windowing}) = nothing
 
-function wE!(S::LSSSchur,Δt,dt,alpha)
+function wE!(S::LSSSchur,Δt,dt,LSSregularizer::TimeDilation)
   @unpack wEinv = S
+  @unpack alpha = LSSregularizer
   @. wEinv = Δt/(alpha^2*dt)
   return nothing
 end
@@ -263,9 +267,9 @@ function B!(S::LSSSchur,dt,umid,sense,sensealg)
   return nothing
 end
 
-E!(S::LSSSchur,dudt,alpha::Union{CosWindowing,Cos2Windowing}) = nothing
+E!(S::LSSSchur,dudt,LSSregularizer::Union{CosWindowing,Cos2Windowing}) = nothing
 
-function E!(S::LSSSchur,dudt,alpha)
+function E!(S::LSSSchur,dudt,LSSregularizer::TimeDilation)
   @unpack E = S
   numindvar, Ndt = size(dudt)
   for i=1:Ndt
@@ -302,13 +306,14 @@ function b!(b, prob::ForwardLSSProblem)
 end
 
 function shadow_forward(prob::ForwardLSSProblem; sensealg=prob.sensealg)
-  shadow_forward(prob,sensealg,sensealg.alpha,sensealg.t0skip,sensealg.t1skip)
+  shadow_forward(prob,sensealg,sensealg.LSSregularizer)
 end
 
-function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Number,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,LSSregularizer::TimeDilation)
   @unpack sol, S, F, window, Δt, diffcache, b, w, v, η, res, g, g0, dg, umid = prob
   @unpack wBinv, wEinv, B, E = S
   @unpack dg_val, numparams, numindvar, uf = diffcache
+  @unpack t0skip, t1skip = LSSregularizer
 
   n0 = searchsortedfirst(sol.t, sol.t[1]+t0skip)
   n1 = searchsortedfirst(sol.t, sol.t[end]-t1skip)
@@ -359,7 +364,7 @@ function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Numb
   return res
 end
 
-function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosWindowing,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,LSSregularizer::CosWindowing)
   @unpack sol, S, F, window, Δt, diffcache, b, w, v, dg, res = prob
   @unpack wBinv, B = S
   @unpack dg_val, numparams, numindvar, uf = diffcache
@@ -392,7 +397,7 @@ function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::CosW
   return res
 end
 
-function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,alpha::Cos2Windowing,t0skip,t1skip)
+function shadow_forward(prob::ForwardLSSProblem,sensealg::ForwardLSS,LSSregularizer::Cos2Windowing)
     @unpack sol, S, F, window, Δt, diffcache, b, w, v, dg, res = prob
     @unpack wBinv, B = S
     @unpack dg_val, numparams, numindvar, uf = diffcache
@@ -437,7 +442,7 @@ function accumulate_cost!(dg, u, p, t, sensealg::ForwardLSS, diffcache, indx)
     end
   else
     if dg_val isa Tuple
-      dg[1](dg_val[1], u, p, nothing, indx) # indx = n0 + j - 1 for alpha and j for windowing
+      dg[1](dg_val[1], u, p, nothing, indx) # indx = n0 + j - 1 for LSSregularizer and j for windowing
       dg[2](dg_val[2], u, p, nothing, indx)
       dg_val[1] .*= -1 # flipped concrete_solve sign 
       dg_val[2] .*= -1
@@ -508,9 +513,9 @@ function AdjointLSSProblem(sol, sensealg::AdjointLSS, t=nothing, dg = nothing;
   # compute their values
   discretize_ref_trajectory!(dt, umid, dudt, sol, Ndt)
 
-  S = LSSSchur(dt,u0,numindvar,Nt,Ndt,sensealg.alpha)
+  S = LSSSchur(dt,u0,numindvar,Nt,Ndt,sensealg.LSSregularizer)
 
-  if sensealg.alpha isa Number
+  if sensealg.LSSregularizer isa TimeDilation
     g0 = g(u0,p,tspan[1])
   else
     g0 = nothing
@@ -522,10 +527,10 @@ function AdjointLSSProblem(sol, sensealg::AdjointLSS, t=nothing, dg = nothing;
 
   Δt = tspan[2] - tspan[1]
   wB!(S,Δt,Nt,numindvar,dt)
-  wE!(S,Δt,dt,sensealg.alpha)
+  wE!(S,Δt,dt,sensealg.LSSregularizer)
 
   B!(S,dt,umid,sense,sensealg)
-  E!(S,dudt,sensealg.alpha)
+  E!(S,dudt,sensealg.LSSregularizer)
   F = SchurLU(S)
   wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
 
@@ -581,13 +586,14 @@ function wBcorrect!(S,sol,g,Nt,sense,sensealg,dg)
 end
 
 function shadow_adjoint(prob::AdjointLSSProblem; sensealg=prob.sensealg)
-  shadow_adjoint(prob,sensealg,sensealg.alpha,sensealg.t0skip,sensealg.t1skip)
+  shadow_adjoint(prob,sensealg,sensealg.LSSregularizer)
 end
 
-function shadow_adjoint(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Number,t0skip,t1skip)
+function shadow_adjoint(prob::AdjointLSSProblem,sensealg::AdjointLSS,LSSregularizer::TimeDilation)
   @unpack sol, S, F, Δt, diffcache, h, b, wa, res, g, g0, dg, umid = prob
   @unpack wBinv, B, E = S
   @unpack dg_val, pgpp, pgpp_config, numparams, numindvar, uf, f, f_cache, pJ, pf, paramjac_config = diffcache
+  @unpack t0skip, t1skip = LSSregularizer
 
   b .= E*h + B*wBinv
   wa .= F\b
@@ -629,4 +635,4 @@ function shadow_adjoint(prob::AdjointLSSProblem,sensealg::AdjointLSS,alpha::Numb
   return res
 end
 
-check_for_g(sensealg::Union{ForwardLSS,AdjointLSS},g)=((sensealg.alpha isa Number && g===nothing) && error("Time dilation needs explicit knowledge of g. Either pass `g` as a kwarg to `ForwardLSS(g=g)` or `AdjointLSS(g=g)` or use ForwardLSS/AdjointLSS with windowing."))
+check_for_g(sensealg::Union{ForwardLSS,AdjointLSS},g)=((sensealg.LSSregularizer isa TimeDilation && g===nothing) && error("Time dilation needs explicit knowledge of g. Either pass `g` as a kwarg to `ForwardLSS(g=g)` or `AdjointLSS(g=g)` or use ForwardLSS/AdjointLSS with windowing."))

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -516,13 +516,16 @@ Currently fails on almost every solver.
 struct ZygoteAdjoint <: AbstractAdjointSensitivityAlgorithm{nothing,true,nothing} end
 
 """
-ForwardLSS{CS,AD,FDT,aType,tType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
+ForwardLSS{CS,AD,FDT,RType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
 
-An implementation of the forward
-[least square shadowing](https://arxiv.org/abs/1204.0159) method. For `alpha`,
-one can choose between two different windowing options, `CosWindowing` (default)
-and `Cos2Windowing`, and `alpha::Number` which corresponds to the weight of the
-time dilation term in `ForwardLSS`.
+An implementation of the discrete, forward-mode
+[least squares shadowing](https://arxiv.org/abs/1204.0159) (LSS) method. LSS replaces
+the ill-conditioned initial value probem (`ODEProblem`) for chaotic systems by a 
+well-conditioned least-squares problem. This allows for computing sensitivities of 
+long-time averaged quantities with respect to the parameters of the `ODEProblem`. The 
+computational cost of LSS scales as (number of states x number of time steps). Converges
+to the correct sensitivity at a rate of `T^(-1/2)`, where `T` is the time of the trajectory.
+See `NILSS()` and `NILSAS()` for a more efficient non-intrusive formulation. 
 
 ## Constructor
 
@@ -530,84 +533,151 @@ time dilation term in `ForwardLSS`.
 ForwardLSS(;
           chunk_size=0,autodiff=true,
           diff_type=Val{:central},
-          alpha=CosWindowing(),
-          t0skip=0.0,t1skip=0.0,
+          LSSregularizer=TimeDilation(10.0,0.0,0.0),
           g=nothing)
 ```
 
 ## Keyword Arguments
 
+* `autodiff`: Use automatic differentiation for constructing the Jacobian
+  if the Jacobian needs to be constructed.  Defaults to `true`.
+* `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
+  built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
+  choice of chunk size.
+* `diff_type`: The method used by FiniteDiff.jl for constructing the Jacobian
+  if the full Jacobian is required with `autodiff=false`.
+* `LSSregularizer`: Using `LSSregularizer`, one can choose between three different
+  regularization routines. The default choice is `TimeDilation(10.0,0.0,0.0)`.
+    - `CosWindowing()`: cos windowing of the time grid, i.e. the time grid (saved
+      time steps) is transformed using a cosine. 
+    - `Cos2Windowing()`: cos^2 windowing of the time grid.
+    - `TimeDilation(alpha::Number,t0skip::Number,t1skip::Number)`: Corresponds to 
+      a time dilation. `alpha` controls the weight. `t0skip` and `t1skip` indicate 
+      the times truncated at the beginnning and end of the trajectory, respectively. 
+* `g`: instantaneous objective function of the long-time averaged objective.
+
 ## SciMLProblem Support
+
+This `sensealg` only supports `ODEProblem`s. This `sensealg` does not support 
+events (callbacks). This `sensealg` assumes that the objective is a long-time averaged
+quantity and ergodic, i.e. the time evolution of the system behaves qualitatively the 
+same over infinite time independent of the specified initial conditions, such that only
+the sensitivity with respect to the parameters is of interest.
 
 ## References
 
 Wang, Q., Hu, R., and Blonigan, P. Least squares shadowing sensitivity analysis of
 chaotic limit cycle oscillations. Journal of Computational Physics, 267, 210-224 (2014).
+
+Wang, Q., Convergence of the Least Squares Shadowing Method for Computing Derivative of Ergodic
+Averages, SIAM Journal on Numerical Analysis, 52, 156–170 (2014).
+
+Blonigan, P., Gomez, S., Wang, Q., Least Squares Shadowing for sensitivity analysis of turbulent 
+fluid flows, in: 52nd Aerospace Sciences Meeting, 1–24 (2014).
 """
-struct ForwardLSS{CS,AD,FDT,aType,tType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
-  alpha::aType # alpha: weight of the time dilation term in LSS.
-  t0skip::tType
-  t1skip::tType
+struct ForwardLSS{CS,AD,FDT,RType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
+  LSSregularizer::RType
   g::gType
 end
 Base.@pure function ForwardLSS(;
-                                chunk_size=0,autodiff=true,
-                                diff_type=Val{:central},
-                                alpha=CosWindowing(),
-                                t0skip=0.0,t1skip=0.0,
-                                g=nothing)
-                           
-  ForwardLSS{chunk_size,autodiff,diff_type,typeof(alpha),typeof(t0skip),typeof(g)}(alpha,t0skip,t1skip,g)
+  chunk_size=0, autodiff=true,
+  diff_type=Val{:central},
+  LSSregularizer=TimeDilation(10.0,0.0,0.0),
+  g=nothing)
+
+  ForwardLSS{chunk_size,autodiff,diff_type,typeof(LSSregularizer),typeof(g)}(LSSregularizer, g)
 end
 
 """
-AdjointLSS{CS,AD,FDT,aType,tType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
+AdjointLSS{CS,AD,FDT,RType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
 
-An implementation of the forward
-[least square shadowing](https://arxiv.org/abs/1204.0159) method. For `alpha`,
-one can choose between two different windowing options, `CosWindowing` (default)
-and `Cos2Windowing`, and `alpha::Number` which corresponds to the weight of the
-time dilation term in `ForwardLSS`.
+An implementation of the discrete, adjoint-mode
+[least square shadowing](https://arxiv.org/abs/1204.0159) method. LSS replaces
+the ill-conditioned initial value probem (`ODEProblem`) for chaotic systems by a 
+well-conditioned least-squares problem. This allows for computing sensitivities of 
+long-time averaged quantities with respect to the parameters of the `ODEProblem`. The 
+computational cost of LSS scales as (number of states x number of time steps). Converges
+to the correct sensitivity at a rate of `T^(-1/2)`, where `T` is the time of the trajectory.
+See `NILSS()` and `NILSAS()` for a more efficient non-intrusive formulation. 
 
 ## Constructor
 
 ```julia
-ForwardLSS(;
+AdjointLSS(;
           chunk_size=0,autodiff=true,
           diff_type=Val{:central},
-          alpha=CosWindowing(),
-          t0skip=0.0,t1skip=0.0,
+          LSSRegularizer=CosWindowing(),
           g=nothing)
 ```
 
 ## Keyword Arguments
 
+* `autodiff`: Use automatic differentiation for constructing the Jacobian
+  if the Jacobian needs to be constructed.  Defaults to `true`.
+* `chunk_size`: Chunk size for forward-mode differentiation if full Jacobians are
+  built (`autojacvec=false` and `autodiff=true`). Default is `0` for automatic
+  choice of chunk size.
+* `diff_type`: The method used by FiniteDiff.jl for constructing the Jacobian
+  if the full Jacobian is required with `autodiff=false`.
+* `LSSregularizer`: Using `LSSregularizer`, one can choose between different
+  regularization routines. The default choice is `TimeDilation(10.0,0.0,0.0)`.
+    - `TimeDilation(alpha::Number,t0skip::Number,t1skip::Number)`: Corresponds to 
+      a time dilation. `alpha` controls the weight. `t0skip` and `t1skip` indicate 
+      the times truncated at the beginnning and end of the trajectory, respectively.
+      The default value for `t0skip` and `t1skip` is `zero(alpha)`. 
+* `g`: instantaneous objective function of the long-time averaged objective.
+
 ## SciMLProblem Support
+
+This `sensealg` only supports `ODEProblem`s. This `sensealg` does not support 
+events (callbacks). This `sensealg` assumes that the objective is a long-time averaged
+quantity and ergodic, i.e. the time evolution of the system behaves qualitatively the 
+same over infinite time independent of the specified initial conditions, such that only
+the sensitivity with respect to the parameters is of interest.
 
 ## References
 
 Wang, Q., Hu, R., and Blonigan, P. Least squares shadowing sensitivity analysis of
 chaotic limit cycle oscillations. Journal of Computational Physics, 267, 210-224 (2014).
 """
-struct AdjointLSS{CS,AD,FDT,aType,tType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
-  alpha::aType # alpha: weight of the time dilation term in LSS.
-  t0skip::tType
-  t1skip::tType
+struct AdjointLSS{CS,AD,FDT,RType,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
+  LSSregularizer::RType
   g::gType
 end
 Base.@pure function AdjointLSS(;
-                                chunk_size=0,autodiff=true,
-                                diff_type=Val{:central},
-                                alpha=10.0,
-                                t0skip=0.0,t1skip=0.0,
-                                g=nothing)
-  AdjointLSS{chunk_size,autodiff,diff_type,typeof(alpha),typeof(t0skip),typeof(g)}(alpha,t0skip,t1skip,g)
+  chunk_size=0, autodiff=true,
+  diff_type=Val{:central},
+  LSSregularizer=TimeDilation(10.0, 0.0, 0.0),
+  g=nothing)
+  AdjointLSS{chunk_size,autodiff,diff_type,typeof(LSSregularizer),typeof(g)}(LSSregularizer, g)
 end
 
-abstract type WindowingChoice end
-struct CosWindowing <: WindowingChoice end
-struct Cos2Windowing <: WindowingChoice end
+abstract type AbstractLSSregularizer end
+struct CosWindowing <: AbstractLSSregularizer end
+struct Cos2Windowing <: AbstractLSSregularizer end
 
+"""
+TimeDilation{T1<:Number} <: AbstractLSSregularizer
+
+A regularization method for `LSS`. See `?LSS` for 
+additional information and other methods.
+
+## Constructor
+
+```julia
+TimeDilation(alpha;
+          t0skip=zero(alpha),
+          t1skip=zero(alpha))
+```
+"""
+struct TimeDilation{T1<:Number} <: AbstractLSSregularizer
+  alpha::T1 # alpha: weight of the time dilation term in LSS.
+  t0skip::T1
+  t1skip::T1
+end
+function TimeDilation(alpha,t0skip=zero(alpha),t1skip=zero(alpha))
+  TimeDilation{typeof(alpha)}(alpha,t0skip,t1skip)
+end
 """
 struct NILSS{CS,AD,FDT,RNG,gType} <: AbstractShadowingSensitivityAlgorithm{CS,AD,FDT}
 

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -653,8 +653,9 @@ Base.@pure function AdjointLSS(;
 end
 
 abstract type AbstractLSSregularizer end
-struct CosWindowing <: AbstractLSSregularizer end
-struct Cos2Windowing <: AbstractLSSregularizer end
+abstract type AbstractCosWindowing <: AbstractLSSregularizer end
+struct CosWindowing <: AbstractCosWindowing end
+struct Cos2Windowing <: AbstractCosWindowing end
 
 """
 TimeDilation{T1<:Number} <: AbstractLSSregularizer

--- a/test/sde_nondiag_stratonovich.jl
+++ b/test/sde_nondiag_stratonovich.jl
@@ -248,7 +248,7 @@ end
   prob = SDEProblem(f_mixing!,g_mixing!,u₀,trange,p)
 
   soltsave = collect(trange[1]:dtmix:trange[2])
-  sol = solve(prob, EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave )
+  sol = solve(prob, EulerHeun(), dt=dtmix, save_noise=true, saveat=soltsave)
 
   Random.seed!(seed)
   proboop = SDEProblem(f_mixing,g_mixing,u₀,trange,p)


### PR DESCRIPTION
This PR updates the docs for ForwardLSS and AdjointLSS.
I slightly restructured the keyword arguments. Before a numerical value of the weight `alpha` of the dilation term determined whether dilation (with `t0skip` and `t1skip`) or windowing is used. Now, the weight and the two truncation times are moved to the `TimeDilation` struct and the keyword is called `LSSregularizer`.

(I'll do `NILSS` and `NILSAS` in a follow-up PR)