### PR TITLE
add docs for NILSS and NILSAS

### DIFF
--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -87,11 +87,11 @@ struct NILSSProblem{A,CacheType,FSprob,probType,u0Type,vstar0Type,w0Type,
 end
 
 
-function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing; nus = nothing,
+function NILSSProblem(prob, sensealg::NILSS, t=nothing, dg = nothing; 
                             kwargs...)
 
   @unpack f, p, u0, tspan = prob
-  @unpack nseg, nstep, rng, g = sensealg  #number of segments on time interval, number of steps saved on each segment
+  @unpack nseg, nstep, nus, rng, g = sensealg  #number of segments on time interval, number of steps saved on each segment
 
   numindvar = length(u0)
   numparams = length(p)

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -770,14 +770,14 @@ An implementation of the adjoint-mode, continuous
 `NILSAS` allows for computing sensitivities of long-time averaged quantities with respect 
 to the parameters of an `ODEProblem` by constraining the computation to the unstable subspace.
 `NILSAS` employs SciMLSensitivity.jl's continuous adjoint sensitivity methods on each segment 
-to compute (homogenous and inhomogenous) tangent solutions. To avoid an exponential blow-up 
-of the tangent solutions, the trajectory should be divided into sufficiently small segments, 
-where the tangent solutions are rescaled on the interfaces. The computational and memory cost 
+to compute (homogenous and inhomogenous) adjoint solutions. To avoid an exponential blow-up 
+of the adjoint solutions, the trajectory should be divided into sufficiently small segments, 
+where the adjoint solutions are rescaled on the interfaces. The computational and memory cost 
 of NILSAS scale with the number of unstable, adjoint Lyapunov exponents (instead of the number 
 of states as in the LSS method). `NILSAS` avoids the explicit construction of the Jacobian at 
 each time step and thus should generally be preferred (for large system sizes) over `AdjointLSS`. 
 `NILSAS` is favourable over `NILSS` for many parameters because NILSAS computes the gradient 
-with respect to multiple parameters with negligible additional cost.
+with respect to multiple parameters with negligible additional cost. 
 
 ## Constructor
 


### PR DESCRIPTION
Remaining docstrings for shadowing methods (see https://github.com/SciML/DiffEqSensitivity.jl/issues/582).