### PR TITLE
NILSS fix to reduce memory allocations and remove initial time step estimate

### DIFF
--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -263,7 +263,7 @@ function forward_sense(prob::NILSSProblem,nilss::NILSS,alg)
     # compute y, w, vstar
     # _sol is a numindvar*(1+nus+1) x nstep matrix
                
-    dt = (t2 - t1) / floor(nstep-1)
+    dt = (t2 - t1) / (nstep-1)
     _sol = Array(solve(_prob, alg, saveat=t1:dt:t2))
                     
     store_y_w_vstar!(y, w, vstar, _sol, nus, numindvar, numparams, iseg)

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -262,7 +262,10 @@ function forward_sense(prob::NILSSProblem,nilss::NILSS,alg)
   for iseg=1:nseg
     # compute y, w, vstar
     # _sol is a numindvar*(1+nus+1) x nstep matrix
-    _sol = Array(solve(_prob, alg, saveat=dtsave))
+               
+    dt = (t2 - t1) / floor(nstep-1)
+    _sol = Array(solve(_prob, alg, saveat=t1:dt:t2))
+                    
     store_y_w_vstar!(y, w, vstar, _sol, nus, numindvar, numparams, iseg)
 
     # store dudt, objective g (gsave), and its derivative wrt. to u (dgdu)

--- a/src/nilss.jl
+++ b/src/nilss.jl
@@ -262,7 +262,7 @@ function forward_sense(prob::NILSSProblem,nilss::NILSS,alg)
   for iseg=1:nseg
     # compute y, w, vstar
     # _sol is a numindvar*(1+nus+1) x nstep matrix
-    _sol = Array(solve(_prob, alg, saveat=dtsave, dt=dtsave)(_prob.tspan[1]:dtsave:_prob.tspan[2]))
+    _sol = Array(solve(_prob, alg, saveat=dtsave))
     store_y_w_vstar!(y, w, vstar, _sol, nus, numindvar, numparams, iseg)
 
     # store dudt, objective g (gsave), and its derivative wrt. to u (dgdu)


### PR DESCRIPTION
Before this fix, the shadow forward ODEs would be solved with fixed `dt` dictated by `nseg` and `nstep`. This meant that solver behavior was really inconsistent and output sensitivities could be noisy. Also, memory allocation was very high.

Now, the shadow forward ODEs are solved with adaptive timestep. For larger systems, I've seen this fix reduce computational time and memory usage by 50 to 100x. For the Lorenz 1 parameter system, I've seen it reduce solve times by 10x. This fix is also simultaneously implementing the "snapshotting" method discussed in the NILSS and FD-NILSS paper, since `nstep` is now decoupled from the shadow forward ODE's solver timestep. `nstep` can now be optimized by user to just improve integration estimates of NILSS algorithm internal states instead of trying to optimize for solver behavior and integration estimates simultaneously.

I've confirmed output slopes are correct on the Lorenz 3 parameter system, and tests still pass on my computer.