### PR TITLE
Add high level interpretable error messages for parameter compatability

### DIFF
--- a/src/concrete_solve.jl
+++ b/src/concrete_solve.jl
@@ -96,7 +96,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
                                  save_idxs = nothing,
                                  kwargs...)
  
-  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || (p isa AbstractArray && !Base.isconcretetype(eltype(p)))
     throw(AdjointSensitivityParameterCompatibilityError())
   end
 
@@ -268,7 +268,7 @@ function DiffEqBase._concrete_solve_adjoint(prob, alg, sensealg::AbstractForward
                                             save_idxs=nothing,
                                             kwargs...)
   
-  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || (p isa AbstractArray && !Base.isconcretetype(eltype(p)))
     throw(ForwardSensitivityParameterCompatibilityError())
   end
 
@@ -349,7 +349,7 @@ function DiffEqBase._concrete_solve_adjoint(prob,alg,
                                  u0,p,args...;saveat=eltype(prob.tspan)[],
                                  kwargs...) where {CS,CTS}
   
-  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || (p isa AbstractArray && !Base.isconcretetype(eltype(p)))
     throw(ForwardDiffSensitivityParameterCompatibilityError())
   end
 

--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -135,6 +135,26 @@ function ODEForwardSensitivityProblem(prob::ODEProblem,alg;kwargs...)
   ODEForwardSensitivityProblem(prob.f,prob.u0,prob.tspan,prob.p,alg;kwargs...)
 end
 
+const FORWARD_SENSITIVITY_PARAMETER_COMPATABILITY_MESSAGE = 
+"""
+ODEForwardSensitivityProblem requires being able to solve
+a differential equation defined by the parameter struct `p`. Thus while
+DifferentialEquations.jl can support any parameter struct type, usage
+with ODEForwardSensitivityProblem requires that `p` could be a valid
+type for being the initial condition `u0` of an array. This means that
+many simple types, such as `Tuple`s and `NamedTuple`s, will work as
+parameters in normal contexts but will fail during ODEForwardSensitivityProblem
+construction. To work around this issue for complicated cases like nested structs, 
+look into defining `p` using `AbstractArray` libraries such as RecursiveArrayTools.jl 
+or ComponentArrays.jl.
+"""
+
+struct ForwardSensitivityParameterCompatibilityError <: Exception end
+
+function Base.showerror(io::IO, e::ForwardSensitivityParameterCompatibilityError)
+  print(io, FORWARD_SENSITIVITY_PARAMETER_COMPATABILITY_MESSAGE)
+end
+
 @doc doc"""
 function ODEForwardSensitivityProblem(f::Union{Function,DiffEqBase.AbstractODEFunction},
                                       u0,tspan,p=nothing,
@@ -145,6 +165,19 @@ Local forward sensitivity analysis gives a solution along with a timeseries of
 the sensitivities. Thus if one wishes to have a derivative at every possible
 time point, directly using the `ODEForwardSensitivityProblem` can be the most
 efficient method.
+
+!!! warning
+
+      ODEForwardSensitivityProblem requires being able to solve
+      a differential equation defined by the parameter struct `p`. Thus while
+      DifferentialEquations.jl can support any parameter struct type, usage
+      with ODEForwardSensitivityProblem requires that `p` could be a valid
+      type for being the initial condition `u0` of an array. This means that
+      many simple types, such as `Tuple`s and `NamedTuple`s, will work as
+      parameters in normal contexts but will fail during ODEForwardSensitivityProblem
+      construction. To work around this issue for complicated cases like nested structs, 
+      look into defining `p` using `AbstractArray` libraries such as RecursiveArrayTools.jl 
+      or ComponentArrays.jl.
 
 ### ODEForwardSensitivityProblem Syntax
 
@@ -291,6 +324,11 @@ function ODEForwardSensitivityProblem(f::F,u0,
   isautojacmat = get_jacmat(alg)
   isautojacvec = get_jacvec(alg)
   p === nothing && error("You must have parameters to use parameter sensitivity calculations!")
+
+  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+    throw(ForwardSensitivityParameterCompatibilityError())
+  end
+
   uf = DiffEqBase.UJacobianWrapper(f,tspan[1],p)
   pf = DiffEqBase.ParamJacobianWrapper(f,tspan[1],copy(u0))
   if isautojacmat

--- a/src/forward_sensitivity.jl
+++ b/src/forward_sensitivity.jl
@@ -325,7 +325,7 @@ function ODEForwardSensitivityProblem(f::F,u0,
   isautojacvec = get_jacvec(alg)
   p === nothing && error("You must have parameters to use parameter sensitivity calculations!")
 
-  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+  if !(typeof(p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || (p isa AbstractArray && !Base.isconcretetype(eltype(p)))
     throw(ForwardSensitivityParameterCompatibilityError())
   end
 

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -278,7 +278,7 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
                                    callback = nothing,
                                    kwargs...)
 
-  if !(typeof(sol.prob.p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(sol.prob.p))
+  if !(typeof(sol.prob.p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || (sol.prob.p isa AbstractArray && !Base.isconcretetype(eltype(sol.prob.p)))
     throw(AdjointSensitivityParameterCompatibilityError())
   end
 

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -1,5 +1,25 @@
 ## Direct calls
 
+const ADJOINT_PARAMETER_COMPATABILITY_MESSAGE = 
+"""
+Adjoint sensitivity analysis functionality requires being able to solve
+a differential equation defined by the parameter struct `p`. Thus while
+DifferentialEquations.jl can support any parameter struct type, usage
+with adjoint sensitivity analysis requires that `p` could be a valid
+type for being the initial condition `u0` of an array. This means that
+many simple types, such as `Tuple`s and `NamedTuple`s, will work as
+parameters in normal contexts but will fail during adjoint differentiation.
+To work around this issue for complicated cases like nested structs, look
+into defining `p` using `AbstractArray` libraries such as RecursiveArrayTools.jl 
+or ComponentArrays.jl so that `p` is an `AbstractArray` with a concrete element type.
+"""
+
+struct AdjointSensitivityParameterCompatibilityError <: Exception end
+
+function Base.showerror(io::IO, e::AdjointSensitivityParameterCompatibilityError)
+  print(io, ADJOINT_PARAMETER_COMPATABILITY_MESSAGE)
+end
+
 @doc doc"""
 adjoint_sensitivities(sol,alg,g,t=nothing,dg=nothing;
                             abstol=1e-6,reltol=1e-3,
@@ -22,6 +42,19 @@ of the full concretized solution. It can also allow you to be more efficient
 by directly controlling the forward solve that is then reversed over. Lastly,
 it allows one to define a continuous cost function on the continuous solution,
 instead of just at discrete data points.
+
+!!! warning
+
+      Adjoint sensitivity analysis functionality requires being able to solve
+      a differential equation defined by the parameter struct `p`. Thus while
+      DifferentialEquations.jl can support any parameter struct type, usage
+      with adjoint sensitivity analysis requires that `p` could be a valid
+      type for being the initial condition `u0` of an array. This means that
+      many simple types, such as `Tuple`s and `NamedTuple`s, will work as
+      parameters in normal contexts but will fail during adjoint differentiation.
+      To work around this issue for complicated cases like nested structs, look
+      into defining `p` using `AbstractArray` libraries such as RecursiveArrayTools.jl 
+      or ComponentArrays.jl so that `p` is an `AbstractArray` with a concrete element type.
 
 !!! warning
 
@@ -245,6 +278,10 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
                                    callback = nothing,
                                    kwargs...)
 
+  if !(typeof(sol.prob.p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+    throw(AdjointSensitivityParameterCompatibilityError())
+  end
+
   if sol.prob isa ODEProblem
     adj_prob = ODEAdjointProblem(sol,sensealg,g,t,dg; checkpoints=checkpoints,
                                  callback = callback,
@@ -303,7 +340,20 @@ H = second_order_sensitivities(loss,prob,alg,args...;
                                kwargs...)
 
 Second order sensitivity analysis is used for the fast calculation of Hessian
-matrices. 
+matrices.
+
+!!! warning
+
+      Adjoint sensitivity analysis functionality requires being able to solve
+      a differential equation defined by the parameter struct `p`. Thus while
+      DifferentialEquations.jl can support any parameter struct type, usage
+      with adjoint sensitivity analysis requires that `p` could be a valid
+      type for being the initial condition `u0` of an array. This means that
+      many simple types, such as `Tuple`s and `NamedTuple`s, will work as
+      parameters in normal contexts but will fail during adjoint differentiation.
+      To work around this issue for complicated cases like nested structs, look
+      into defining `p` using `AbstractArray` libraries such as RecursiveArrayTools.jl 
+      or ComponentArrays.jl so that `p` is an `AbstractArray` with a concrete element type.
 
 ### Example second order sensitivity analysis calculation
 
@@ -347,6 +397,19 @@ Hv = second_order_sensitivity_product(loss,v,prob,alg,args...;
 Second order sensitivity analysis product is used for the fast calculation of 
 Hessian-vector products ``Hv`` without requiring the construction of the Hessian
 matrix.
+
+!!! warning
+
+      Adjoint sensitivity analysis functionality requires being able to solve
+      a differential equation defined by the parameter struct `p`. Thus while
+      DifferentialEquations.jl can support any parameter struct type, usage
+      with adjoint sensitivity analysis requires that `p` could be a valid
+      type for being the initial condition `u0` of an array. This means that
+      many simple types, such as `Tuple`s and `NamedTuple`s, will work as
+      parameters in normal contexts but will fail during adjoint differentiation.
+      To work around this issue for complicated cases like nested structs, look
+      into defining `p` using `AbstractArray` libraries such as RecursiveArrayTools.jl 
+      or ComponentArrays.jl so that `p` is an `AbstractArray` with a concrete element type.
 
 ### Example second order sensitivity analysis calculation
 

--- a/src/sensitivity_interface.jl
+++ b/src/sensitivity_interface.jl
@@ -278,7 +278,7 @@ function _adjoint_sensitivities(sol,sensealg,alg,g,t=nothing,dg=nothing;
                                    callback = nothing,
                                    kwargs...)
 
-  if !(typeof(sol.prob.p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(p))
+  if !(typeof(sol.prob.p) <: Union{Nothing,SciMLBase.NullParameters,AbstractArray}) || !Base.isconcretetype(eltype(sol.prob.p))
     throw(AdjointSensitivityParameterCompatibilityError())
   end
 

--- a/test/parameter_compatibility_errors.jl
+++ b/test/parameter_compatibility_errors.jl
@@ -1,0 +1,50 @@
+using OrdinaryDiffEq, DiffEqSensitivity, Zygote, Test
+
+function f!(du,u,p,t)
+    du[1] = -p[1]'*u
+    du[2] = (p[2].a + p[2].b)u[2]
+    du[3] = p[3](u,t)
+    return nothing
+end
+
+struct mystruct
+    a
+    b
+end
+
+function control(u,t)
+    return -exp(-t)*u[3]
+end
+
+u0 = [10,15,20]
+p = [[1;2;3], mystruct(-1,-2), control]
+tspan = (0.0,10.0)
+
+prob = ODEProblem(f!,u0, tspan, p)
+
+sol = solve(prob, Tsit5()) # Solves without errors
+
+function loss(p1)
+    sol = solve(prob, Tsit5(), p=[p1, mystruct(-1,-2), control])
+    return sum(abs2, sol)
+end
+
+grad(p) = Zygote.gradient(loss, p)
+
+p2 = [4;5;6]
+@test_throws DiffEqSensitivity.ForwardDiffSensitivityParameterCompatibilityError grad(p2)
+
+function loss(p1)
+    sol = solve(prob, Tsit5(), p=[p1, mystruct(-1,-2), control], sensealg = InterpolatingAdjoint())
+    return sum(abs2, sol)
+end
+
+@test_throws DiffEqSensitivity.AdjointSensitivityParameterCompatibilityError grad(p2)
+
+function loss(p1)
+    sol = solve(prob, Tsit5(), p=[p1, mystruct(-1,-2), control], sensealg = ForwardSensitivity())
+    return sum(abs2, sol)
+end
+
+@test_throws DiffEqSensitivity.ForwardSensitivityParameterCompatibilityError grad(p2)
+@test_throws DiffEqSensitivity.ForwardSensitivityParameterCompatibilityError ODEForwardSensitivityProblem(f!,u0, tspan, p)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ if GROUP == "All" || GROUP == "Core2"
     @time @safetestset "Forward Mode Prob Kwargs" begin include("forward_prob_kwargs.jl") end
     @time @safetestset "Steady State Adjoint" begin include("steady_state.jl") end
     @time @safetestset "Concrete Solve Derivatives of Second Order ODEs" begin include("second_order_odes.jl") end
+    @time @safetestset "Parameter Compatibility Errors" begin include("parameter_compatibility_errors.jl") end
 end
 
 if GROUP == "All" || GROUP == "Core3" || GROUP == "Downstream"


### PR DESCRIPTION
Note that this will change somewhat when the higher level interface for SciMLParameters is well-defined, but for now this will be helpful for folks who are confused, such as in https://discourse.julialang.org/t/parameter-types-in-diffeqflux-jl-versus-differentialequations-jl/79635