### PR TITLE
Test and fix `VectorContinuousCallback`

### DIFF
--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -314,16 +314,18 @@ end
 
 get_indx(cb::DiscreteCallback,t) = (searchsortedfirst(cb.affect!.event_times,t), true)
 function get_indx(cb::Union{ContinuousCallback,VectorContinuousCallback}, t)
-  if !isempty(cb.affect!.event_times)
+  if !isempty(cb.affect!.event_times) || !isempty(cb.affect_neg!.event_times)
     indx = searchsortedfirst(cb.affect!.event_times,t)
     indx_neg = searchsortedfirst(cb.affect_neg!.event_times,t)
-    if cb.affect!.event_times[min(indx,length(cb.affect!.event_times))]==t
+    if !isempty(cb.affect!.event_times) && cb.affect!.event_times[min(indx,length(cb.affect!.event_times))]==t
       return indx, true
-    elseif cb.affect_neg!.event_times[min(indx_neg,length(cb.affect_neg!.event_times))]==t
+    elseif !isempty(cb.affect_neg!.event_times) && cb.affect_neg!.event_times[min(indx_neg,length(cb.affect_neg!.event_times))]==t
       return indx_neg, false
     else
       error("Event was triggered but no corresponding event in ContinuousCallback was found. Please report this error.")
     end
+  else
+    error("No event was recorded. Please report this error.")
   end
 end
 

--- a/src/callback_tracking.jl
+++ b/src/callback_tracking.jl
@@ -33,8 +33,7 @@ function ImplicitCorrection(cb,t,u,p,sensealg)
   gu_val = similar(u)
 
   fakeinteg = FakeIntegrator(u,p,t,t)
-  gt = ConditionTimeWrapper(condition,u,fakeinteg)
-  gu = ConditionUWrapper(condition,t,fakeinteg)
+  gt, gu = build_condition_wrappers(cb,condition,u,t,fakeinteg)
 
   gt_conf = build_deriv_config(sensealg,gt,gt_val,t)
   gu_conf = build_grad_config(sensealg,gu,u,p)
@@ -42,7 +41,7 @@ function ImplicitCorrection(cb,t,u,p,sensealg)
 
   dy_left = similar(u)
   dy_right = similar(u)
-  
+
   Lu_left = similar(u)
   Lu_right = similar(u)
 
@@ -52,34 +51,47 @@ function ImplicitCorrection(cb,t,u,p,sensealg)
   ImplicitCorrection(gt_val,gu_val,gt,gu,gt_conf,gu_conf,condition,Lu_left,Lu_right,dy_left,dy_right,cur_time,terminated)
 end
 
-struct TrackedAffect{T,T2,T3,T4,T5}
+struct TrackedAffect{T,T2,T3,T4,T5,T6}
     event_times::Vector{T}
     tprev::Vector{T}
     uleft::Vector{T2}
     pleft::Vector{T3}
     affect!::T4
     correction::T5
+    event_idx::Vector{T6}
 end
 
 TrackedAffect(t::Number,u,p,affect!::Nothing,correction) = nothing
-TrackedAffect(t::Number,u,p,affect!,correction) = TrackedAffect(Vector{typeof(t)}(undef,0),Vector{typeof(t)}(undef,0),Vector{typeof(u)}(undef,0),Vector{typeof(p)}(undef,0),affect!,correction)
+TrackedAffect(t::Number,u,p,affect!,correction) = TrackedAffect(Vector{typeof(t)}(undef,0),Vector{typeof(t)}(undef,0),
+                                                                Vector{typeof(u)}(undef,0),Vector{typeof(p)}(undef,0),affect!,correction,
+                                                                Vector{Int}(undef,0))
 
-function (f::TrackedAffect)(integrator)
+function (f::TrackedAffect)(integrator,event_idx=nothing)
     uleft = deepcopy(integrator.u)
     pleft = deepcopy(integrator.p)
-    f.affect!(integrator)
+    if event_idx===nothing
+      f.affect!(integrator)
+    else
+      f.affect!(integrator,event_idx)
+    end
     if integrator.u_modified
         if isempty(f.event_times)
           push!(f.event_times,integrator.t)
           push!(f.tprev,integrator.tprev)
           push!(f.uleft,uleft)
           push!(f.pleft,pleft)
+          if event_idx !== nothing
+            push!(f.event_idx,event_idx)
+          end
         else
           if !maximum(.≈(integrator.t, f.event_times, rtol=0.0, atol=1e-14))
             push!(f.event_times,integrator.t)
             push!(f.tprev,integrator.tprev)
             push!(f.uleft,uleft)
             push!(f.pleft,pleft)
+            if event_idx !== nothing
+              push!(f.event_idx, event_idx)
+            end
           end
         end
     end
@@ -158,43 +170,48 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
       cb.affect!.correction.terminated = terminated # flag if time evolution was terminated by callback
     end
 
-    # ReverseLossCallback adds gradients before and after the callback if save_positions is (true, true). 
-    # This, however, means that we must check the save_positions setting within the callback. 
-    # if save_positions = [1,1] is true the loss gradient is accumulated correctly before and after callback. 
-    # if save_positions = [0,0] no extra gradient is added. 
-    # if save_positions = [0,1] the gradient contribution is added before the callback but no additional gradient is added afterwards. 
+    # ReverseLossCallback adds gradients before and after the callback if save_positions is (true, true).
+    # This, however, means that we must check the save_positions setting within the callback.
+    # if save_positions = [1,1] is true the loss gradient is accumulated correctly before and after callback.
+    # if save_positions = [0,0] no extra gradient is added.
+    # if save_positions = [0,1] the gradient contribution is added before the callback but no additional gradient is added afterwards.
     # if save_positions = [1,0] the gradient contribution is added before, and in principle we would need to correct the adjoint state again. Thefore,
-    
+
     cb.save_positions == [1,0] && error("save_positions=[1,0] is currently not supported.")
 
     function affect!(integrator)
 
-        indx, pos_neg = get_indx(cb, integrator.t)
+        indx, pos_neg = get_indx(cb,integrator.t)
         tprev = get_tprev(cb,indx,pos_neg)
+        event_idx = cb isa VectorContinuousCallback ? get_event_idx(cb,indx,pos_neg) : nothing
 
-        function w(du,u,p,t,tprev,pos_neg)
-          _affect! = get_affect!(cb,pos_neg)
-          fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
-          _affect!(fakeinteg)
-          du .= fakeinteg.u
+        w = let tprev=tprev, pos_neg=pos_neg, event_idx=event_idx
+              function (du,u,p,t)
+                _affect! = get_affect!(cb,pos_neg)
+                fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
+                if cb isa VectorContinuousCallback
+                  _affect!(fakeinteg,event_idx)
+                else
+                  _affect!(fakeinteg)
+                end
+                du .= fakeinteg.u
+              end
         end
-
         S = integrator.f.f # get the sensitivity function
 
         # Create a fake sensitivity function to do the vjps
-        fakeS = CallbackSensitivityFunction((du,u,p,t)->w(du,u,p,t,tprev,pos_neg),sensealg,
-                        S.diffcache,integrator.sol.prob)
+        fakeS = CallbackSensitivityFunction(w,sensealg,S.diffcache,integrator.sol.prob)
 
         du = first(get_tmp_cache(integrator))
         λ,grad,y,dλ,dgrad,dy = split_states(du,integrator.u,integrator.t,S)
 
-        # if save_positions[2] = false, then the right limit is not saved. Thus, for 
+        # if save_positions[2] = false, then the right limit is not saved. Thus, for
         # the QuadratureAdjoint we would need to lift y from the left to the right limit.
         # However, one also needs to update dgrad later on.
         if (sensealg isa QuadratureAdjoint && !cb.save_positions[2]) # || (sensealg isa InterpolatingAdjoint && ischeckpointing(sensealg))
-          # lifting for InterpolatingAdjoint is not needed anymore. Callback is already applied. 
-          w(y,y,integrator.p,integrator.t,tprev,pos_neg)
-        end 
+          # lifting for InterpolatingAdjoint is not needed anymore. Callback is already applied.
+          w(y,y,integrator.p,integrator.t)
+        end
 
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
           # correction of the loss function sensitivity for continuous callbacks
@@ -226,37 +243,42 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
           # compute the correction of the right limit (with left state limit inserted into dgdt)
           @unpack dy_left, cur_time = correction
           compute_f!(dy_left,S,y,integrator)
-          dgdt(dy_left,correction,sensealg,y,integrator,tprev)
+          dgdt(dy_left,correction,sensealg,y,integrator,tprev,event_idx)
           if !correction.terminated
             implicit_correction!(Lu_right,dλ,λ,dy_right,correction)
-            correction.terminated = false # additional callbacks might have happened which didn't terminate the time evolution  
+            correction.terminated = false # additional callbacks might have happened which didn't terminate the time evolution
           end
         end
 
         if update_p
           # changes in parameters
           if !(sensealg isa QuadratureAdjoint)
-            
-            function wp(dp,p,u,t,tprev,pos_neg)
-              _affect! = get_affect!(cb,pos_neg)
-              fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
-              _affect!(fakeinteg)
-              dp .= fakeinteg.p
-            end
 
-            fakeSp = CallbackSensitivityFunction((du,u,p,t)->wp(du,u,p,t,tprev,pos_neg),sensealg,S.diffcache,integrator.sol.prob)
+            wp = let tprev=tprev, pos_neg=pos_neg, event_idx=event_idx
+              function (dp,p,u,t)
+                _affect! = get_affect!(cb,pos_neg)
+                fakeinteg = FakeIntegrator([x for x in u],[x for x in p],t,tprev)
+                if cb isa VectorContinuousCallback
+                  _affect!(fakeinteg, event_idx)
+                else
+                  _affect!(fakeinteg)
+                end
+                dp .= fakeinteg.p
+              end
+            end
+            fakeSp = CallbackSensitivityFunction(wp,sensealg,S.diffcache,integrator.sol.prob)
             #vjp with Jacobin given by dw/dp before event and vector given by grad
             vecjacobian!(dgrad, integrator.p, grad, y, integrator.t, fakeSp;
                                   dgrad=nothing, dy=nothing)
             grad .= dgrad
           end
         end
-        
+
 
         vecjacobian!(dλ, y, λ, integrator.p, integrator.t, fakeS;
                               dgrad=dgrad, dy=dy)
 
-      
+
         if cb isa Union{ContinuousCallback,VectorContinuousCallback}
           # second correction to correct for left limit
           @unpack Lu_left = correction
@@ -265,7 +287,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
 
           if cb.save_positions[1] == true
             # if the callback saved the first position, we need to implicitly correct this value as well
-            loss_indx = correction.cur_time[] 
+            loss_indx = correction.cur_time[]
             implicit_correction!(Lu_left,dy_left,correction,y,integrator,g,loss_indx)
             dλ .+= Lu_left
           end
@@ -276,7 +298,7 @@ function _setup_reverse_callbacks(cb::Union{ContinuousCallback,DiscreteCallback,
         if !(sensealg isa QuadratureAdjoint)
           grad .-= dgrad
         end
-        
+
     end
 
     times = if typeof(cb) <: DiscreteCallback
@@ -294,15 +316,15 @@ get_indx(cb::DiscreteCallback,t) = (searchsortedfirst(cb.affect!.event_times,t),
 function get_indx(cb::Union{ContinuousCallback,VectorContinuousCallback}, t)
   if !isempty(cb.affect!.event_times)
     indx = searchsortedfirst(cb.affect!.event_times,t)
-    if cb.affect!.event_times[indx]!=t
-      bool = false
-      indx = searchsortedfirst(cb.affect_neg!.event_times,t)
-    else
+    indx_neg = searchsortedfirst(cb.affect_neg!.event_times,t)
+    if cb.affect!.event_times[min(indx,length(cb.affect!.event_times))]==t
       bool = true
+    elseif cb.affect_neg!.event_times[min(indx_neg,length(cb.affect_neg!.event_times))]==t
+      indx = indx_neg
+      bool = false
+    else
+      error("Event was triggered but no corresponding event in ContinuousCallback was found. Please report this error.")
     end
-  else
-    bool = false
-    indx = searchsortedfirst(cb.affect_neg!.event_times,t)
   end
   return indx, bool
 end
@@ -313,6 +335,14 @@ function get_tprev(cb::Union{ContinuousCallback,VectorContinuousCallback}, indx,
     return cb.affect!.tprev[indx]
   else
     return cb.affect_neg!.tprev[indx]
+  end
+end
+
+function get_event_idx(cb::VectorContinuousCallback, indx, bool)
+  if bool
+    return cb.affect!.event_idx[indx]
+  else
+    return cb.affect_neg!.event_idx[indx]
   end
 end
 
@@ -347,7 +377,7 @@ function compute_f!(dy,S,y,integrator)
   return nothing
 end
 
-function dgdt(dy,correction,sensealg,y,integrator,tprev)
+function dgdt(dy,correction,sensealg,y,integrator,tprev,event_idx)
   # dy refers to f evaluated on left limit
   @unpack gt_val, gu_val, gt, gu, gt_conf, gu_conf, condition = correction
 
@@ -362,6 +392,12 @@ function dgdt(dy,correction,sensealg,y,integrator,tprev)
   gu.t = t
   gu.integrator = fakeinteg
 
+  # for VectorContinuousCallback we also need to set the event_idx.
+  if gt isa VectorConditionTimeWrapper
+    gt.event_idx = event_idx
+    gu.event_idx = event_idx
+  end
+
   derivative!(gt_val, gt, t, sensealg, gt_conf)
   gradient!(gu_val, gu, y, sensealg, gu_conf)
 
@@ -369,7 +405,6 @@ function dgdt(dy,correction,sensealg,y,integrator,tprev)
   @. gt_val = inv(gt_val) # allocates?
 
   @. gu_val *= -gt_val
-
   return nothing
 end
 
@@ -410,30 +445,55 @@ function implicit_correction!(Lu,dy,correction,y,integrator,g,indx)
 
   Lu .= dot(Lu,dy)*gu_val
 
-  # note that we don't add the gradient Lu here again to the correction because it will be added by the ReverseLossCallback. 
+  # note that we don't add the gradient Lu here again to the correction because it will be added by the ReverseLossCallback.
   return nothing
 end
 
+# ConditionTimeWrapper: Wrapper for implicit correction for ContinuousCallback
+# VectorConditionTimeWrapper: Wrapper for implicit correction for VectorContinuousCallback
+function build_condition_wrappers(cb::ContinuousCallback,condition,u,t,fakeinteg)
+  gt = ConditionTimeWrapper(condition,u,fakeinteg)
+  gu = ConditionUWrapper(condition,t,fakeinteg)
+  return gt, gu
+end
+function build_condition_wrappers(cb::VectorContinuousCallback,condition,u,t,fakeinteg)
+  gt = VectorConditionTimeWrapper(condition,u,fakeinteg,1)
+  gu = VectorConditionUWrapper(condition,t,fakeinteg,1)
+  return gt, gu
+end
 mutable struct ConditionTimeWrapper{F,uType,Integrator} <: Function
   f::F
   u::uType
   integrator::Integrator
 end
 (ff::ConditionTimeWrapper)(t) = [ff.f(ff.u,t,ff.integrator)]
-
 mutable struct ConditionUWrapper{F,tType,Integrator} <: Function
   f::F
   t::tType
   integrator::Integrator
 end
 (ff::ConditionUWrapper)(u) = ff.f(u,ff.t,ff.integrator)
+mutable struct VectorConditionTimeWrapper{F,uType,Integrator} <: Function
+  f::F
+  u::uType
+  integrator::Integrator
+  event_idx::Int
+end
+(ff::VectorConditionTimeWrapper)(t) = [ff.f(ff.u,t,ff.integrator)]
+
+mutable struct VectorConditionUWrapper{F,tType,Integrator} <: Function
+  f::F
+  t::tType
+  integrator::Integrator
+  event_idx::Int
+end
+(ff::VectorConditionUWrapper)(u) = ff.f(u,ff.t,ff.integrator)
 
 DiffEqBase.terminate!(i::FakeIntegrator) = nothing
 
-# get the affect function of the callback. For example, allows us to get the `f` in PeriodicCallback without the integrator.tstops handling.  
+# get the affect function of the callback. For example, allows us to get the `f` in PeriodicCallback without the integrator.tstops handling.
 get_affect!(cb::DiscreteCallback,bool) = get_affect!(cb.affect!)
 get_affect!(cb::ContinuousCallback,bool) = bool ? get_affect!(cb.affect!) : get_affect!(cb.affect_neg!)
 get_affect!(affect!::TrackedAffect) = get_affect!(affect!.affect!)
 get_affect!(affect!) = affect!
 get_affect!(affect!::DiffEqCallbacks.PeriodicCallbackAffect) = affect!.affect!
-

--- a/test/callbacks/vector_continuous_callbacks.jl
+++ b/test/callbacks/vector_continuous_callbacks.jl
@@ -49,7 +49,7 @@ end
         end
       end
       cb = VectorContinuousCallback(condition, affect!, 2)
-      test_vector_continuous_callback(cb, g, dg!)
+      test_vector_continuous_callback(cb, g)
     end
   end
 end

--- a/test/callbacks/vector_continuous_callbacks.jl
+++ b/test/callbacks/vector_continuous_callbacks.jl
@@ -1,0 +1,55 @@
+using OrdinaryDiffEq, Zygote
+using DiffEqSensitivity, Test, ForwardDiff
+
+abstol = 1e-12
+reltol = 1e-12
+savingtimes = 0.5
+
+# see https://diffeq.sciml.ai/stable/features/callback_functions/#VectorContinuousCallback-Example
+function test_vector_continuous_callback(cb,g)
+
+  function f(du, u, p, t)
+    du[1] = u[2]
+    du[2] = -p[1]
+    du[3] = u[4]
+    du[4] = 0.0
+  end
+
+  u0 = [50.0, 0.0, 0.0, 2.0]
+  tspan = (0.0, 10.0)
+  p = [9.8, 0.9]
+  prob = ODEProblem(f,u0,tspan,p)
+  sol = solve(prob, Tsit5(), callback=cb, abstol=abstol, reltol=reltol, saveat=savingtimes)
+
+  du01, dp1 = @time Zygote.gradient(
+      (u0, p) -> g(solve(prob, Tsit5(), u0=u0, p=p, callback=cb, abstol=abstol, reltol=reltol, saveat=savingtimes, sensealg=BacksolveAdjoint())),
+      u0, p)
+
+  dstuff = @time ForwardDiff.gradient(
+      (θ) -> g(solve(prob, Tsit5(), u0=θ[1:4], p=θ[5:6], callback=cb, abstol=abstol, reltol=reltol, saveat=savingtimes)),
+      [u0; p])
+
+  @test du01 ≈ dstuff[1:4]
+  @test dp1 ≈ dstuff[5:6]
+end
+
+@testset "VectorContinuous callbacks" begin
+  @testset "MSE loss function bouncing-ball like" begin
+    g(u) = sum((1.0.-u).^2)./2
+    function condition(out, u, t, integrator) # Event when event_f(u,t) == 0
+      out[1] = u[1]
+      out[2] = (u[3]-10.0)u[3]
+    end
+    @testset "callback with linear affect" begin
+      function affect!(integrator, idx)
+        if idx == 1
+            integrator.u[2] = -integrator.p[2]*integrator.u[2]
+        elseif idx == 2
+            integrator.u[4] = -integrator.p[2]*integrator.u[4]
+        end
+      end
+      cb = VectorContinuousCallback(condition, affect!, 2)
+      test_continuous_callback(cb, g, dg!)
+    end
+  end
+end

--- a/test/callbacks/vector_continuous_callbacks.jl
+++ b/test/callbacks/vector_continuous_callbacks.jl
@@ -49,7 +49,7 @@ end
         end
       end
       cb = VectorContinuousCallback(condition, affect!, 2)
-      test_continuous_callback(cb, g, dg!)
+      test_vector_continuous_callback(cb, g, dg!)
     end
   end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,7 @@ end
 if GROUP == "Callbacks2"
     @time @safetestset "Continuous vs. discrete Callbacks" begin include("callbacks/continuous_vs_discrete.jl") end
     @time @safetestset "Continuous Callbacks with Adjoints" begin include("callbacks/continuous_callbacks.jl") end
+    @time @safetestset "VectorContinuousCallbacks with Adjoints" begin include("callbacks/vector_continuous_callbacks.jl") end
 end
 
 if GROUP == "Shadowing"


### PR DESCRIPTION
`VectorContinuousCallback`s are not fully implemented or tested yet (see e.g. https://github.com/SciML/DiffEqSensitivity.jl/issues/564). This PR adds a test and

- [x]  in contrast to `ContinuousCallback`s, we also have to track event indices for `VectorContinuousCallback`s. 
- [x]   `get_indx(cb::Union{ContinuousCallback,VectorContinuousCallback}, t)` always checked first for an event in `affect!`. However, if the last event is in `affect_neg!`, `searchsortedfirst` provided an index > `len(event_times)`. This is now solved by the `min()` function. 
- [x]  the condition function `g` in `VectorContinuousCallback`s operates on a vector. (in contrast to a scalar condition in `ContinuousCallback`s.). Therefore, the wrappers for computing the derivative `dg/dt` and the gradient `dg/du` must be adjusted.
- [x]  need to think about how to handle several true conditions for a single event? 