### PR TITLE
Test for using callbacks within `ForwardDiffSensitivity`

### DIFF
--- a/test/callbacks/forward_sensitivity_callback.jl
+++ b/test/callbacks/forward_sensitivity_callback.jl
@@ -21,7 +21,8 @@ function test_discrete_callback(cb, tstops, g)
   @show g(solve(prob, Tsit5(), callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes))
 
   du01, dp1 = Zygote.gradient(
-    (u0, p) -> g(solve(prob, Tsit5(), u0=u0, p=p, callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes, sensealg=ForwardDiffSensitivity(;        convert_tspan=true))),
+    (u0, p) -> g(solve(prob, Tsit5(), u0=u0, p=p, callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes,
+      sensealg=ForwardDiffSensitivity(;convert_tspan=true))),
     u0, p)
 
   dstuff1 = ForwardDiff.gradient(

--- a/test/callbacks/forward_sensitivity_callback.jl
+++ b/test/callbacks/forward_sensitivity_callback.jl
@@ -1,0 +1,52 @@
+using OrdinaryDiffEq, DiffEqCallbacks
+using DiffEqSensitivity, Zygote, Test
+import ForwardDiff
+import FiniteDiff
+
+abstol = 1e-6
+reltol = 1e-6
+savingtimes = 0.1
+
+function test_discrete_callback(cb, tstops, g)
+  function fiip(du, u, p, t)
+    #du[1] = dx = p[1]*u[1]
+    du[:] .= p[1]*u
+  end
+
+  p = Float64[0.8123198]
+  u0 = Float64[1.0]
+
+  prob = ODEProblem(fiip, u0, (0.0, 1.0), p)
+
+  @show g(solve(prob, Tsit5(), callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes))
+
+  du01, dp1 = Zygote.gradient(
+    (u0, p) -> g(solve(prob, Tsit5(), u0=u0, p=p, callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes, sensealg=ForwardDiffSensitivity(;        convert_tspan=true))),
+    u0, p)
+
+  dstuff1 = ForwardDiff.gradient(
+    (θ) -> g(solve(prob, Tsit5(), u0=θ[1:1], p=θ[2:2], callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes)),
+    [u0; p])
+
+  dstuff2 = FiniteDiff.finite_difference_gradient(
+    (θ) -> g(solve(prob, Tsit5(), u0=θ[1:1], p=θ[2:2], callback=cb, tstops=tstops, abstol=abstol, reltol=reltol, saveat=savingtimes)),
+    [u0; p])
+
+  @show du01 dp1 dstuff1 dstuff2
+  @test du01 ≈ dstuff1[1:1] atol=1e-6
+  @test dp1 ≈ dstuff1[2:2] atol=1e-6
+  @test du01 ≈ dstuff2[1:1] atol=1e-6
+  @test dp1 ≈ dstuff2[2:2] atol=1e-6
+end
+
+@testset "ForwardDiffSensitivity: Discrete callbacks" begin
+  g(u) = sum(u.^2)
+  @testset "reset to initial condition" begin
+    affecttimes = range(0.0, 1.0, length=6)[2:end]
+    u0 = [1.0]
+    condition(u, t, integrator) = t ∈ affecttimes
+    affect!(integrator) = (integrator.u .= u0; @show "triggered!")
+    cb = DiscreteCallback(condition, affect!, save_positions=(false,false))
+    test_discrete_callback(cb, affecttimes, g)
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -83,6 +83,7 @@ if GROUP == "All" || GROUP == "SDE3"
 end
 
 if GROUP == "Callbacks1"
+    @time @safetestset "Discrete Callbacks with ForwardDiffSensitivity" begin include("callbacks/forward_sensitivity_callback.jl") end
     @time @safetestset "Discrete Callbacks with Adjoints" begin include("callbacks/discrete_callbacks.jl") end
     @time @safetestset "SDE Callbacks" begin include("callbacks/SDE_callbacks.jl") end
 end


### PR DESCRIPTION
Handling callbacks in `ForwardDiffSensitivity` seems to be really tricky (noted before e.g. in https://github.com/SciML/DiffEqSensitivity.jl/pull/436). When digging into https://github.com/SciML/DiffEqSensitivity.jl/issues/567, I found that I can reproduce the error by a simple `DiscreteCallback`.

Under the hood -- even with a chunk size of 1, depending on the tolerances used by the solver and the frequency of the callback -- events are missed in  https://github.com/SciML/DiffEqSensitivity.jl/blob/2a919aa43b3a6da47243901e912008a8f52b3b95/src/concrete_solve.jl#L450

That is, while the callback is triggered in the forward pass at all anticipated event times, it is not triggered (or only at the first even time or only at some of them) within the augmented forward-sensitivity solve call. 

```julia
g(solve(prob, Tsit5(), callback = cb, tstops = tstops, abstol = abstol, reltol = reltol, saveat = savingtimes)) = 13.801684f0
"triggered!" = "triggered!"
"triggered!" = "triggered!"
"triggered!" = "triggered!"
"triggered!" = "triggered!"
"triggered!" = "triggered!"
sol.t = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
ts = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
---------
[ Info: backpass!!
---------
"triggered!" = "triggered!"
kwargs[:callback] = DiscreteCallback{var"#condition#41"{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}, var"#affect!#42"{Vector{Float64}}, typeof(SciMLBase.INITIALIZE_DEFAULT), typeof(SciMLBase.FINALIZE_DEFAULT)}(var"#condition#41"{StepRangeLen{Float64, Base.TwicePrecision{Float64}, Base.TwicePrecision{Float64}, Int64}}(0.2:0.2:1.0), var"#affect!#42"{Vector{Float64}}([1.0]), SciMLBase.INITIALIZE_DEFAULT, SciMLBase.FINALIZE_DEFAULT, Bool[0, 0])
kwargs[:tstops] = 0.2:0.2:1.0
"triggered!" = "triggered!" # This should occur 5 times 
ForwardDiff.value.(_sol.t) = Float32[0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
```
Note that the solver indeed steps to the event times but no `affect!` is triggered.

This happened despite setting `tstops` at the `affect!` times.  Narrowing it down, it can be seen that this is a floating-point issue in the check of the CB `condition`. The MWE in the test set works fine. However, when changing 

```julia
p = Float64[0.8123198]
u0 = Float64[1.0]
```
to 

```julia
p = Float32[0.8123198]
u0 = Float32[1.0]
```
the error occurs. 

I checked that, as discussed in https://github.com/SciML/DiffEqSensitivity.jl/issues/567, the `convert_tspan=false` setting is generally incorrect (but in this MWE it does actually work). 