### PR TITLE
Improve SteadyStateAdjoint linear solver handling

### DIFF
--- a/test/steady_state.jl
+++ b/test/steady_state.jl
@@ -274,3 +274,4 @@ using Zygote
     @test res1oop[1] ≈ dp2oop[1] rtol=1e-10
   end
 end
+


### PR DESCRIPTION
- Always use the user's `linsolve` choice
- If the user chooses `linsolve`, know whether to take a Jacobian depending on whether it allows matrix-free
- Cut an allocation