### PR TITLE
Don't allow Zygote to return nothing by default

### DIFF
--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -26,12 +26,6 @@ import ChainRulesCore: unthunk, @thunk, NoTangent, @not_implemented
 abstract type SensitivityFunction end
 abstract type TransformedFunction end
 
-const ALLOW_ZYGOTEVJP_NOTHING = Ref{Bool}(false)
-allow_zygotevjp_nothing(b::Bool) = (ALLOW_ZYGOTEVJP_NOTHING[] = b)
-
-const ALLOW_TRACKERVJP_NOTHING = Ref{Bool}(false)
-allow_trackervjp_nothing(b::Bool) = (ALLOW_TRACKERVJP_NOTHING[] = b)
-
 include("hasbranching.jl")
 include("sensitivity_algorithms.jl")
 include("derivative_wrappers.jl")

--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -26,6 +26,9 @@ import ChainRulesCore: unthunk, @thunk, NoTangent, @not_implemented
 abstract type SensitivityFunction end
 abstract type TransformedFunction end
 
+const ALLOW_ZYGOTEVJP_NOTHING = Ref{Bool}(false)
+allow_zygotevjp_nothing(b::Bool) = (ALLOW_ZYGOTEVJP_NOTHING[] = b)
+
 include("hasbranching.jl")
 include("sensitivity_algorithms.jl")
 include("derivative_wrappers.jl")

--- a/src/DiffEqSensitivity.jl
+++ b/src/DiffEqSensitivity.jl
@@ -29,6 +29,9 @@ abstract type TransformedFunction end
 const ALLOW_ZYGOTEVJP_NOTHING = Ref{Bool}(false)
 allow_zygotevjp_nothing(b::Bool) = (ALLOW_ZYGOTEVJP_NOTHING[] = b)
 
+const ALLOW_TRACKERVJP_NOTHING = Ref{Bool}(false)
+allow_trackervjp_nothing(b::Bool) = (ALLOW_TRACKERVJP_NOTHING[] = b)
+
 include("hasbranching.jl")
 include("sensitivity_algorithms.jl")
 include("derivative_wrappers.jl")

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -357,7 +357,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
     end
 
     if !(typeof(_dy) isa TrackedArray) && !(eltype(_dy) <: Tracker.TrackedReal) && 
-                                          !sensealg.allow_nothing
+                                          !sensealg.autojacvec.allow_nothing
       throw(TrackerVJPNothingError())
     end
 
@@ -380,7 +380,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
     end
 
     if !(typeof(_dy) isa TrackedArray) && !(eltype(_dy) <: Tracker.TrackedReal) && 
-                                          !sensealg.allow_nothing
+                                          !sensealg.autojacvec.allow_nothing
       throw(TrackerVJPNothingError())
     end
 
@@ -532,7 +532,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
     tmp1,tmp2 = back(λ)
     dλ[:] .= vec(tmp1)
     if dgrad !== nothing 
-      if tmp2 === nothing && !sensealg.allow_nothing
+      if tmp2 === nothing && !sensealg.autojacvec.allow_nothing
         throw(ZygoteVJPNothingError())
       else
         (dgrad[:] .= vec(tmp2))
@@ -553,14 +553,14 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
     dy !== nothing && (dy[:] .= vec(_dy))
 
     tmp1, tmp2 = back(λ)
-    if tmp1 === nothing && !sensealg.allow_nothing
+    if tmp1 === nothing && !sensealg.autojacvec.allow_nothing
       throw(ZygoteVJPNothingError())
     elseif tmp1 !== nothing
       (dλ[:] .= vec(tmp1))
     end
 
     if dgrad !== nothing 
-      if tmp2 === nothing && !sensealg.allow_nothing
+      if tmp2 === nothing && !sensealg.autojacvec.allow_nothing
         throw(ZygoteVJPNothingError())
       elseif tmp2 !== nothing
         (dgrad[:] .= vec(tmp2))

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -357,7 +357,7 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::TrackerVJP, dgrad,
     end
 
     if !(typeof(_dy) isa TrackedArray) && !(eltype(_dy) <: Tracker.TrackedReal) && 
-                                          !ALLOW_TRACKERVJP_NOTHING[]
+                                          !sensealg.allow_nothing
       throw(TrackerVJPNothingError())
     end
 
@@ -553,14 +553,14 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
     dy !== nothing && (dy[:] .= vec(_dy))
 
     tmp1, tmp2 = back(λ)
-    if tmp1 === nothing && sensealg.allow_nothing
+    if tmp1 === nothing && !sensealg.allow_nothing
       throw(ZygoteVJPNothingError())
     elseif tmp1 !== nothing
       (dλ[:] .= vec(tmp1))
     end
 
     if dgrad !== nothing 
-      if tmp2 === nothing && !ALLOW_ZYGOTEVJP_NOTHING[] 
+      if tmp2 === nothing && !sensealg.allow_nothing
         throw(ZygoteVJPNothingError())
       elseif tmp2 !== nothing
         (dgrad[:] .= vec(tmp2))

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -306,7 +306,7 @@ end
 const TRACKERVJP_NOTHING_MESSAGE = 
 """
 `nothing` returned from a Tracker vector-Jacobian product (vjp) calculation.
-This indicates that your function `f` is not a function of `p`, i.e. that
+This indicates that your function `f` is not a function of `p` or `u`, i.e. that
 the derivative is constant zero. In many cases this is due to an error in
 the model definition, for example accidentally using a global parameter
 instead of the one in the model (`f(u,p,t)= _p .* u`).
@@ -470,7 +470,7 @@ end
 const ZYGOTEVJP_NOTHING_MESSAGE = 
 """
 `nothing` returned from a Zygote vector-Jacobian product (vjp) calculation.
-This indicates that your function `f` is not a function of `p`, i.e. that
+This indicates that your function `f` is not a function of `p` or `u`, i.e. that
 the derivative is constant zero. In many cases this is due to an error in
 the model definition, for example accidentally using a global parameter
 instead of the one in the model (`f(u,p,t)= _p .* u`).

--- a/src/derivative_wrappers.jl
+++ b/src/derivative_wrappers.jl
@@ -547,14 +547,14 @@ function _vecjacobian!(dλ, y, λ, p, t, S::TS, isautojacvec::ZygoteVJP, dgrad, 
     tmp1, tmp2 = back(λ)
     if tmp1 === nothing && !ALLOW_ZYGOTEVJP_NOTHING[]
       throw(ZygoteVJPNothingError())
-    else
+    elseif tmp1 !== nothing
       (dλ[:] .= vec(tmp1))
     end
 
     if dgrad !== nothing 
       if tmp2 === nothing && !ALLOW_ZYGOTEVJP_NOTHING[] 
         throw(ZygoteVJPNothingError())
-      else 
+      elseif tmp2 !== nothing
         (dgrad[:] .= vec(tmp2))
       end
     end

--- a/src/sensitivity_algorithms.jl
+++ b/src/sensitivity_algorithms.jl
@@ -927,10 +927,24 @@ performance of the VJP method.
 ## Constructor
 
 ```julia
-ZygoteVJP(compile=false)
+ZygoteVJP(;allow_nothing=false)
 ```
+
+Keyword arguments:
+
+* `allow_nothing`: whether `nothing`s should be implicitly converted to zeros. In Zygote,
+  the derivative of a function with respect to `p` which does not use `p` in any possible
+  calculation is given a derivative of `nothing` instead of zero. By default, this `nothing`
+  is caught in order to throw an informative error message about a potentially unintentional
+  misdefined function. However, if this was intentional, setting `allow_nothing=true` will
+  remove the error message.
+
 """
-struct ZygoteVJP <: VJPChoice end
+struct ZygoteVJP <: VJPChoice 
+  allow_nothing::Bool
+end
+ZygoteVJP(;allow_nothing=false) = ZygoteVJP(allow_nothing)
+
 
 """
 EnzymeVJP <: VJPChoice
@@ -963,10 +977,22 @@ reverse mode.
 ## Constructor
 
 ```julia
-TrackerVJP(compile=false)
+TrackerVJP(;allow_nothing=false)
 ```
+
+Keyword arguments:
+
+* `allow_nothing`: whether non-tracked values should be implicitly converted to zeros. In Tracker,
+  the derivative of a function with respect to `p` which does not use `p` in any possible
+  calculation is given an untracked return instead of zero. By default, this `nothing` Trackedness
+  is caught in order to throw an informative error message about a potentially unintentional
+  misdefined function. However, if this was intentional, setting `allow_nothing=true` will
+  remove the error message.
 """
-struct TrackerVJP <: VJPChoice end
+struct TrackerVJP <: VJPChoice 
+  allow_nothing::Bool
+end
+TrackerVJP(;allow_nothing=false) = TrackerVJP(allow_nothing)
 
 """
 ReverseDiffVJP{compile} <: VJPChoice

--- a/test/array_partitions.jl
+++ b/test/array_partitions.jl
@@ -7,10 +7,11 @@ import DiffEqSensitivity:
     InterpolatingAdjoint,
     ZygoteVJP,
     ReverseDiffVJP
+    allow_zygotevjp_nothing
 import RecursiveArrayTools: ArrayPartition
 
 # There are no parameters, so required
-DiffEqSensitivity.allow_zygotevjp_nothing(true)
+allow_zygotevjp_nothing(true)
 
 sol = solve(
     DynamicalODEProblem(
@@ -31,7 +32,7 @@ sol = solve(
 solve(
     ODEAdjointProblem(
         sol,
-        InterpolatingAdjoint(autojacvec=ZygoteVJP()),
+        InterpolatingAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)),
         (out, x, p, t, i) -> (out .= 0),
         [sol.t[end]],
     ),OrdinaryDiffEq.Tsit5()
@@ -70,12 +71,10 @@ g = ArrayPartition(ArrayPartition(zeros(), zero(v0)), ArrayPartition(zeros(), ze
 bwd_sol = solve(
     ODEAdjointProblem(
         sol,
-        InterpolatingAdjoint(autojacvec=ZygoteVJP()),
+        InterpolatingAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)),
         # Also fails, but due to a different bug:
         # InterpolatingAdjoint(autojacvec=ReverseDiffVJP()),
         (out, x, p, t, i) -> (out[:] = g),
         [sol.t[end]],
     ),OrdinaryDiffEq.Tsit5()
 )
-
-DiffEqSensitivity.allow_zygotevjp_nothing(false)

--- a/test/array_partitions.jl
+++ b/test/array_partitions.jl
@@ -9,6 +9,9 @@ import DiffEqSensitivity:
     ReverseDiffVJP
 import RecursiveArrayTools: ArrayPartition
 
+# There are no parameters, so required
+DiffEqSensitivity.allow_zygotevjp_nothing(true)
+
 sol = solve(
     DynamicalODEProblem(
         (v, x, p, t) -> [0.0, 0.0],
@@ -62,9 +65,6 @@ sol = solve(
     # Without setting parameters, we end up with https://github.com/SciML/DifferentialEquations.jl/issues/679 again.
     p = zeros()
 )
-
-# There are no parameters, so required
-DiffEqSensitivity.allow_zygotevjp_nothing(true)
 
 g = ArrayPartition(ArrayPartition(zeros(), zero(v0)), ArrayPartition(zeros(), zero(x0)))
 bwd_sol = solve(

--- a/test/array_partitions.jl
+++ b/test/array_partitions.jl
@@ -63,6 +63,9 @@ sol = solve(
     p = zeros()
 )
 
+# There are no parameters, so required
+DiffEqSensitivity.allow_zygotevjp_nothing(true)
+
 g = ArrayPartition(ArrayPartition(zeros(), zero(v0)), ArrayPartition(zeros(), zero(x0)))
 bwd_sol = solve(
     ODEAdjointProblem(
@@ -74,3 +77,5 @@ bwd_sol = solve(
         [sol.t[end]],
     ),OrdinaryDiffEq.Tsit5()
 )
+
+DiffEqSensitivity.allow_zygotevjp_nothing(false)

--- a/test/array_partitions.jl
+++ b/test/array_partitions.jl
@@ -7,11 +7,7 @@ import DiffEqSensitivity:
     InterpolatingAdjoint,
     ZygoteVJP,
     ReverseDiffVJP
-    allow_zygotevjp_nothing
 import RecursiveArrayTools: ArrayPartition
-
-# There are no parameters, so required
-allow_zygotevjp_nothing(true)
 
 sol = solve(
     DynamicalODEProblem(

--- a/test/complex_no_u.jl
+++ b/test/complex_no_u.jl
@@ -2,6 +2,9 @@ using OrdinaryDiffEq, DiffEqSensitivity, LinearAlgebra, Optimization, Optimizati
 nn = Chain(Dense(1,16),Dense(16,16,tanh),Dense(16,2))
 initial,re = Flux.destructure(nn)
 
+# There are no state used in the ODE, so required
+DiffEqSensitivity.allow_zygotevjp_nothing(true)
+
 function ode2!(u, p, t)
     f1, f2 = re(p)([t]) .+ im
     [-f1^2; f2]
@@ -18,3 +21,5 @@ end
 optf = Optimization.OptimizationFunction((x,p) -> loss(x), Optimization.AutoZygote())
 optprob = Optimization.OptimizationProblem(optf, initial)
 res = Optimization.solve(optprob, ADAM(0.1), maxiters = 100)
+
+DiffEqSensitivity.allow_zygotevjp_nothing(false)

--- a/test/complex_no_u.jl
+++ b/test/complex_no_u.jl
@@ -2,9 +2,6 @@ using OrdinaryDiffEq, DiffEqSensitivity, LinearAlgebra, Optimization, Optimizati
 nn = Chain(Dense(1,16),Dense(16,16,tanh),Dense(16,2))
 initial,re = Flux.destructure(nn)
 
-# There are no state used in the ODE, so required
-DiffEqSensitivity.allow_zygotevjp_nothing(true)
-
 function ode2!(u, p, t)
     f1, f2 = re(p)([t]) .+ im
     [-f1^2; f2]
@@ -14,12 +11,10 @@ tspan = (0.0, 10.0)
 prob = ODEProblem(ode2!, Complex{Float64}[0;0], tspan, initial)
 
 function loss(p)
-  sol = last(solve(prob, Tsit5(), p=p, sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP())))
+  sol = last(solve(prob, Tsit5(), p=p, sensealg=BacksolveAdjoint(autojacvec=ZygoteVJP(allow_nothing=true))))
   return norm(sol)
 end
 
 optf = Optimization.OptimizationFunction((x,p) -> loss(x), Optimization.AutoZygote())
 optprob = Optimization.OptimizationProblem(optf, initial)
 res = Optimization.solve(optprob, ADAM(0.1), maxiters = 100)
-
-DiffEqSensitivity.allow_zygotevjp_nothing(false)

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -96,4 +96,4 @@ end
 @test_broken Zygote.gradient(loss7, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss8, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss9, zeros(123))[1] == zeros(123)
-@test_throws ZygoteVJPNothingError Zygote.gradient(loss10, zeros(123))[1] == zeros(123)
+@test_throws DiffEqSensitivity.ZygoteVJPNothingError Zygote.gradient(loss10, zeros(123))[1] == zeros(123)

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -2,15 +2,12 @@ import OrdinaryDiffEq: ODEProblem, solve, Tsit5
 import Zygote
 using DiffEqSensitivity, Test
 
-# There are no parameters, so required
-DiffEqSensitivity.allow_zygotevjp_nothing(true)
-
 dynamics = (x, _p, _t) -> x
 
 function loss(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0), params)
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = InterpolatingAdjoint(autojacvec=ZygoteVJP()))
+    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = InterpolatingAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)))
     sum(Array(rollout)[:, end])
 end
 
@@ -24,14 +21,14 @@ end
 function loss3(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0), params)
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = InterpolatingAdjoint(autojacvec=TrackerVJP()))
+    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = InterpolatingAdjoint(autojacvec=TrackerVJP(allow_nothing=true)))
     sum(Array(rollout)[:, end])
 end
 
 function loss4(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = InterpolatingAdjoint(autojacvec=ZygoteVJP()))
+    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = InterpolatingAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)))
     sum(Array(rollout)[:, end])
 end
 
@@ -45,14 +42,14 @@ end
 function loss6(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = BacksolveAdjoint(autojacvec=ZygoteVJP()))
+    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = BacksolveAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)))
     sum(Array(rollout)[:, end])
 end
 
 function loss7(params)
     u0 = zeros(2)
     problem = ODEProblem(dynamics, u0, (0.0, 1.0))
-    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = QuadratureAdjoint(autojacvec=ZygoteVJP()))
+    rollout = solve(problem, Tsit5(), u0 = u0, p = params, sensealg = QuadratureAdjoint(autojacvec=ZygoteVJP(allow_nothing=true)))
     sum(Array(rollout)[:, end])
 end
 
@@ -100,5 +97,3 @@ end
 @test Zygote.gradient(loss8, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss9, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss10, zeros(123))[1] == zeros(123)
-
-DiffEqSensitivity.allow_zygotevjp_nothing(false)

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -2,6 +2,9 @@ import OrdinaryDiffEq: ODEProblem, solve, Tsit5
 import Zygote
 using DiffEqSensitivity, Test
 
+# There are no parameters, so required
+DiffEqSensitivity.allow_zygotevjp_nothing(true)
+
 dynamics = (x, _p, _t) -> x
 
 function loss(params)
@@ -97,3 +100,5 @@ end
 @test Zygote.gradient(loss8, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss9, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss10, zeros(123))[1] == zeros(123)
+
+DiffEqSensitivity.allow_zygotevjp_nothing(false)

--- a/test/null_parameters.jl
+++ b/test/null_parameters.jl
@@ -96,4 +96,4 @@ end
 @test_broken Zygote.gradient(loss7, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss8, zeros(123))[1] == zeros(123)
 @test Zygote.gradient(loss9, zeros(123))[1] == zeros(123)
-@test Zygote.gradient(loss10, zeros(123))[1] == zeros(123)
+@test_throws ZygoteVJPNothingError Zygote.gradient(loss10, zeros(123))[1] == zeros(123)


### PR DESCRIPTION
This is a small QOL change which makes it so ZygoteVJPs will throw an error if they have a `nothing` return, which is an implicit zero derivative due to not having parameters defined. This is the case where you have `f(u,p,t)` and then the user doesn't use `p`, for example `f(u,p,t) = NN(u)` instead of `re(p)(u)`. This sanity check will help users realize when they are accidentally using global variables instead of local variables and thus not differentiating w.r.t. `p`.