### PR TITLE
[ci-skip] Redo badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 
 [![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
-[![Build Status](https://github.com/SciML/DiffEqSensitivity.jl/workflows/CI/badge.svg)](https://github.com/SciML/DiffEqSensitivity.jl/actions?query=workflow%3ACI)
-[![Build status](https://badge.buildkite.com/e0ee4d9d914eb44a43c291d78c53047eeff95e7edb7881b6f7.svg)](https://buildkite.com/julialang/diffeqsensitivity-dot-jl)
-[![codecov](https://codecov.io/gh/SciML/DiffEqSensitivity.jl/branch/master/graph/badge.svg?token=FwXaKBNW67)](https://codecov.io/gh/SciML/DiffEqSensitivity.jl)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](http://sensitivity.sciml.ai/stable/)
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/dev/modules/DiffEqSensitivity/)
+
+[![codecov](https://codecov.io/gh/SciML/DiffEqSensitivity.jl/branch/master/graph/badge.svg?token=FwXaKBNW67)](https://codecov.io/gh/SciML/DiffEqSensitivity.jl)
+[![Build Status](https://github.com/SciML/DiffEqSensitivity.jl/workflows/CI/badge.svg)](https://github.com/SciML/DiffEqSensitivity.jl/actions?query=workflow%3ACI)
+[![Build status](https://badge.buildkite.com/e0ee4d9d914eb44a43c291d78c53047eeff95e7edb7881b6f7.svg)](https://buildkite.com/julialang/diffeqsensitivity-dot-jl)
 
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@
 [![codecov](https://codecov.io/gh/SciML/DiffEqSensitivity.jl/branch/master/graph/badge.svg?token=FwXaKBNW67)](https://codecov.io/gh/SciML/DiffEqSensitivity.jl)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](http://sensitivity.sciml.ai/stable/)
 [![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/dev/modules/DiffEqSensitivity/)
+
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
+[![Package Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/DiffEqSensitivity)](https://pkgs.genieframework.com?packages=DiffEqSensitivity)
 
 DiffEqSensitivity.jl is a component package in the [SciML Scientific Machine Learning ecosystem](https://sciml.ai/). 
 It holds the sensitivity analysis utilities. Users interested in using this

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # DiffEqSensitivity.jl
 
-[![Join the chat at https://gitter.im/JuliaDiffEq/Lobby](https://badges.gitter.im/JuliaDiffEq/Lobby.svg)](https://gitter.im/JuliaDiffEq/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+
+[![Join the chat at https://julialang.zulipchat.com #sciml-bridged](https://img.shields.io/static/v1?label=Zulip&message=chat&color=9558b2&labelColor=389826)](https://julialang.zulipchat.com/#narrow/stream/279055-sciml-bridged)
 [![Build Status](https://github.com/SciML/DiffEqSensitivity.jl/workflows/CI/badge.svg)](https://github.com/SciML/DiffEqSensitivity.jl/actions?query=workflow%3ACI)
 [![Build status](https://badge.buildkite.com/e0ee4d9d914eb44a43c291d78c53047eeff95e7edb7881b6f7.svg)](https://buildkite.com/julialang/diffeqsensitivity-dot-jl)
+[![codecov](https://codecov.io/gh/SciML/DiffEqSensitivity.jl/branch/master/graph/badge.svg?token=FwXaKBNW67)](https://codecov.io/gh/SciML/DiffEqSensitivity.jl)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](http://sensitivity.sciml.ai/stable/)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](http://sensitivity.sciml.ai/dev/)
+[![Global Docs](https://img.shields.io/badge/docs-SciML-blue.svg)](https://docs.sciml.ai/dev/modules/DiffEqSensitivity/)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![SciML Code Style](https://img.shields.io/static/v1?label=code%20style&message=SciML&color=9558b2&labelColor=389826)](https://github.com/SciML/SciMLStyle)
 
@@ -14,7 +16,6 @@ functionality should check out [DifferentialEquations.jl](https://github.com/Jul
 
 ## Tutorials and Documentation
 
-For information on using the package,
-[see the stable documentation](https://sensitivity.sciml.ai/stable/). Use the
-[in-development documentation](https://sensitivity.sciml.ai/dev/) for the version of
-the documentation, which contains the unreleased features.
+For information on using the package, see the [DiffEqSensitivity](https://docs.sciml.ai/dev/modules/DiffEqSensitivity/) section of the
+[SciML docs](docs.sciml.ai). For information on specific previous versions of this package, see the 
+[see the stable DiffEqSensitivity-only documentation](https://sensitivity.sciml.ai/stable/).


### PR DESCRIPTION
Major questions:

- We're going to have to move off of Slack to Zulip sometime, I guess we just do the badges now?
- Docs: do we point everyone to the unified docs? I think so. https://docs.sciml.ai/dev/modules/DiffEqSensitivity/ but then we don't have versioning